### PR TITLE
Wait to render templates until hass object is available

### DIFF
--- a/cypress/fixtures/harness.html
+++ b/cypress/fixtures/harness.html
@@ -26,6 +26,11 @@
     const now = new Date();
     now.setMinutes(0);
     h.hass = {
+      connection: {
+        subscribeMessage: (/** @type {(msg: string) => void} */ cb, /** @type {{template: string}} */ { template }) => {
+          cb(template.replace(/\{\{\s*/, '').replace(/\s*\}\}/, ''));
+        },
+      },
       states: {
         'weather.mock': {
           attributes: {


### PR DESCRIPTION
Something changed at some point that makes the card receive an undefined `hass` object sometimes. This PR adds better guards to avoid null/undefined references in that scenario.

Closes #92 