### PR TITLE
Add (optional) precipitation amount

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,24 +56,25 @@ Otherwise, the integration may complain of a duplicate unique ID.
 
 ## Options
 
-| Name              | Type   | Requirement  | Description                                               | Default             |
-| ----------------- | ------ | ------------ | --------------------------------------------------------- | ------------------- |
-| type              | string | **Required** | `custom:hourly-weather`                                   |                     |
-| entity            | string | **Required** | Home Assistant weather entity ID.                         |                     |
-| name              | string | **Optional** | Card name (set to `null` to hide)                         | `Hourly Weather`    |
-| icons             | bool   | **Optional** | Whether to show icons instead of text labels              | `false`             |
-| num_segments      | number | **Optional** | Number of forecast segments to show (even integer >= 2)   | `12`                |
-| ~~num_hours~~     | number | **Optional** | _Deprecated:_ Use `num_segments` instead                  | `12`                |
-| offset            | number | **Optional** | Number of forecast segments to offset from start          | `0`                 |
-| label_spacing     | number | **Optional** | Space between time/temperature labels (even integer >= 2) | `2`                 |
-| colors            | object | **Optional** | Set colors for all or some conditions                     |                     |
-| hide_hours        | bool   | **Optional** | Whether to hide hour labels under the bar                 | `false`             |
-| hide_temperatures | bool   | **Optional** | Whether to hide temeratures under the bar                 | `false`             |
-| show_wind         | bool   | **Optional** | Whether to show wind speed and direction under the bar    | `false`             |
-| tap_action        | object | **Optional** | Action to take on tap                                     | `action: more-info` |
-| hold_action       | object | **Optional** | Action to take on hold                                    | `none`              |
-| double_tap_action | object | **Optional** | Action to take on double tap                              | `none`              |
-| language          | string | **Optional** | Language to use for card (overrides HA & user settings)   |                     |
+| Name               | Type   | Requirement  | Description                                               | Default             |
+| ------------------ | ------ | ------------ | --------------------------------------------------------- | ------------------- |
+| type               | string | **Required** | `custom:hourly-weather`                                   |                     |
+| entity             | string | **Required** | Home Assistant weather entity ID.                         |                     |
+| name               | string | **Optional** | Card name (set to `null` to hide)                         | `Hourly Weather`    |
+| icons              | bool   | **Optional** | Whether to show icons instead of text labels              | `false`             |
+| num_segments       | number | **Optional** | Number of forecast segments to show (even integer >= 2)   | `12`                |
+| ~~num_hours~~      | number | **Optional** | _Deprecated:_ Use `num_segments` instead                  | `12`                |
+| offset             | number | **Optional** | Number of forecast segments to offset from start          | `0`                 |
+| label_spacing      | number | **Optional** | Space between time/temperature labels (even integer >= 2) | `2`                 |
+| colors             | object | **Optional** | Set colors for all or some conditions                     |                     |
+| hide_hours         | bool   | **Optional** | Whether to hide hour labels under the bar                 | `false`             |
+| hide_temperatures  | bool   | **Optional** | Whether to hide temeratures under the bar                 | `false`             |
+| show_wind          | bool   | **Optional** | Whether to show wind speed and direction under the bar    | `false`             |
+| show_precipitation | bool   | **Optional** | Whether to show precipitation (rain) amount under the bar | `false`             |
+| tap_action         | object | **Optional** | Action to take on tap                                     | `action: more-info` |
+| hold_action        | object | **Optional** | Action to take on hold                                    | `none`              |
+| double_tap_action  | object | **Optional** | Action to take on double tap                              | `none`              |
+| language           | string | **Optional** | Language to use for card (overrides HA & user settings)   |                     |
 
 ### Templating
 

--- a/cypress/e2e/weather-bar.cy.ts
+++ b/cypress/e2e/weather-bar.cy.ts
@@ -305,5 +305,41 @@ describe('Weather bar', () => {
           cy.wrap(el).should('have.text', `${expectedWindSpeeds[i]} mph${expectedWindDirections[i]}`);
         });
     });
+
+    it('does not show precipitation by default', () => {
+      cy.get('weather-bar')
+        .shadow()
+        .find('div.axes > div.bar-block div.precipitation')
+        .should('have.length', 6)
+        .each((el) => {
+          cy.wrap(el).should('be.empty');
+        });
+    });
+
+    const expectedPrecipitation = [
+      0.35,
+      1.3,
+      0,
+      0,
+      0,
+      0,
+    ];
+
+    it('shows precipitation if specified in config', () => {
+      cy.configure({
+        show_precipitation: true
+      });
+      cy.get('weather-bar')
+        .shadow()
+        .find('div.axes > div.bar-block div.precipitation')
+        .should('have.length', 6)
+        .each((el, i) => {
+          if (expectedPrecipitation[i] === 0) {
+            cy.wrap(el).should('be.empty');
+          } else {
+            cy.wrap(el).should('have.text', `${expectedPrecipitation[i]} in`);
+          }
+        });
+    });
   });
 });

--- a/cypress/fixtures/harness.html
+++ b/cypress/fixtures/harness.html
@@ -35,6 +35,7 @@
         'weather.mock': {
           attributes: {
             wind_speed_unit: "mph",
+            precipitation_unit: "in",
             forecast: [
             {
               "datetime": "2022-07-21T17:00:00+00:00",
@@ -49,7 +50,7 @@
             },
             {
               "datetime": "2022-07-21T18:00:00+00:00",
-              "precipitation": 0,
+              "precipitation": 0.35,
               "precipitation_probability": 0,
               "pressure": 1007,
               "wind_speed": 6.07,
@@ -71,7 +72,7 @@
             },
             {
               "datetime": "2022-07-21T20:00:00+00:00",
-              "precipitation": 0,
+              "precipitation": 1.3,
               "precipitation_probability": 1,
               "pressure": 1007,
               "wind_speed": 5.9,

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -62,6 +62,10 @@ export class HourlyWeatherCardEditor extends ScopedRegistryHost(LitElement) impl
     return this._config?.show_wind ?? false;
   }
 
+  get _show_precipitation(): boolean {
+    return this._config?.show_precipitation ?? false;
+  }
+
   get _offset(): string {
     return this._config?.offset ?? '0';
   }
@@ -143,6 +147,13 @@ export class HourlyWeatherCardEditor extends ScopedRegistryHost(LitElement) impl
         <mwc-switch
           .checked=${this._show_wind === true}
           .configValue=${'show_wind'}
+          @change=${this._valueChanged}
+        ></mwc-switch>
+      </mwc-formfield>
+      <mwc-formfield .label=${localize('editor.show_precipitation')}>
+        <mwc-switch
+          .checked=${this._show_precipitation === true}
+          .configValue=${'show_precipitation'}
           @change=${this._valueChanged}
         ></mwc-switch>
       </mwc-formfield>

--- a/src/localize/languages/en.json
+++ b/src/localize/languages/en.json
@@ -13,7 +13,8 @@
     "offset": "Number of forecast segments to offset start by (Optional)",
     "icons": "Show icons instead of text labels",
     "label_spacing": "Number of forecast segments to space time and temperature labels by (Optional)",
-    "show_wind": "Show wind speed and direction"
+    "show_wind": "Show wind speed and direction",
+    "show_precipitation": "Show precipitation (rain) amount"
   },
   "errors": {
     "missing_entity": "entity is missing in configuration",

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,6 +20,7 @@ export interface HourlyWeatherCardConfig extends LovelaceCardConfig {
   hide_hours?: boolean;
   hide_temperatures?: boolean;
   show_wind?: boolean;
+  show_precipitation?: boolean;
   label_spacing?: string; // number
   test_gui?: boolean;
   tap_action?: ActionConfig;
@@ -72,6 +73,11 @@ export interface SegmentWind {
   hour: string,
   windSpeed: string,
   windDirection: string
+}
+
+export interface SegmentPrecipitation {
+  hour: string,
+  precipitationAmount: string
 }
 
 export type ColorMap = Map<keyof ColorConfig, string>

--- a/src/weather-bar.ts
+++ b/src/weather-bar.ts
@@ -3,7 +3,7 @@ import { property } from "lit/decorators.js";
 import { StyleInfo, styleMap } from 'lit/directives/style-map.js';
 import tippy, { Instance } from 'tippy.js';
 import { LABELS, ICONS } from "./conditions";
-import type { ColorMap, ConditionSpan, SegmentTemperature, SegmentWind } from "./types";
+import type { ColorMap, ConditionSpan, SegmentTemperature, SegmentWind, SegmentPrecipitation } from "./types";
 
 const tippyStyles: string = process.env.TIPPY_CSS || '';
 
@@ -16,6 +16,9 @@ export class WeatherBar extends LitElement {
 
   @property({ type: Array })
   wind: SegmentWind[] = [];
+
+  @property({ type: Array })
+  precipitation: SegmentPrecipitation[] = [];
 
   @property({ type: Boolean })
   icons = false;
@@ -31,6 +34,9 @@ export class WeatherBar extends LitElement {
 
   @property({ type: Boolean })
   show_wind = false;
+
+  @property({ type: Boolean })
+  show_precipitation = false;
 
   @property({ type: Number })
   label_spacing = 2;
@@ -64,8 +70,10 @@ export class WeatherBar extends LitElement {
       const hideHours = this.hide_hours || skipLabel;
       const hideTemperature = this.hide_temperatures || skipLabel;
       const showWind = this.show_wind && !skipLabel;
+      const showPrecipitation = this.show_precipitation && !skipLabel;
       const { hour, temperature } = this.temperatures[i];
       const { windSpeed, windDirection } = this.wind[i];
+      const { precipitationAmount } = this.precipitation[i];
       barBlocks.push(html`
         <div class="bar-block">
           <div class="bar-block-left"></div>
@@ -74,6 +82,7 @@ export class WeatherBar extends LitElement {
             <div class="hour">${hideHours ? null : hour}</div>
             <div class="temperature">${hideTemperature ? null : html`${temperature}&deg;`}</div>
             <div class="wind">${showWind ? html`${windSpeed}<br>${windDirection}` : null }</div>
+            <div class="precipitation">${showPrecipitation ? html`${precipitationAmount}` : null }</div>
           </div>
         </div>
       `);
@@ -253,7 +262,8 @@ export class WeatherBar extends LitElement {
     .temperature {
       font-size: 1.1rem;
     }
-    .wind {
+    .wind,
+    .precipitation {
       font-size: 0.9rem;
       line-height: 1.1rem;
       padding-top: 0.1rem;


### PR DESCRIPTION
Adds an option to display precipitation amounts.

I noticed that there's a feature request for precipitation amounts, so I've implemented it following the same patterns as in #182 (wind forecast).

Closes #142 