### PR TITLE
Fix wind direction not showing when bearing approaches 360 degrees

### DIFF
--- a/cypress/e2e/weather-bar.cy.ts
+++ b/cypress/e2e/weather-bar.cy.ts
@@ -288,7 +288,7 @@ describe('Weather bar', () => {
       'WSW',
       'W',
       'WNW',
-      'WNW',
+      'N',
       'WNW',
       'WNW'
     ];

--- a/cypress/fixtures/harness.html
+++ b/cypress/fixtures/harness.html
@@ -120,7 +120,7 @@
               "precipitation_probability": 0,
               "pressure": 1009,
               "wind_speed": 5.68,
-              "wind_bearing": 302,
+              "wind_bearing": 359,
               "condition": "sunny",
               "clouds": 3,
               "temperature": 75

--- a/src/hourly-weather.ts
+++ b/src/hourly-weather.ts
@@ -117,6 +117,8 @@ export class HourlyWeatherCard extends LitElement {
   private get directions(): Array<string> {
     if (!this.directionsLocalized || this.localizerSettingsChanged) {
       this._directions = Object.values(DIRECTIONS).map((msg) => this.localize(msg));
+      // Add North to the end for values approaching 360 degrees.
+      this._directions.push(this._directions[0]);
       this.directionsLocalized = true;
     }
     return this._directions;


### PR DESCRIPTION
When adding localization support to the wind directions, we lost the "N" at the end of the array of directions which is used when the bearing approaches 360 degrees.  Copying the first element onto the end of the directions array fixes this while retaining localizataion capability.

I've also tweaked the test data to include a bearing of 359° in order to cover this scenario so that any regression should be picked up by the tests.
 
Fixes #159 