### PR TITLE
Handle knots with kn abbreviation properly

### DIFF
--- a/src/hourly-weather.ts
+++ b/src/hourly-weather.ts
@@ -400,6 +400,7 @@ export class HourlyWeatherCard extends LitElement {
       case 'ft/s':
         return speed * 0.3048;
       case 'kt':
+      case 'kn':
         return speed * 0.51444444444444;
     }
     return -1;


### PR DESCRIPTION
Fixes #239 

Knots can have unit abbreviation `kt` or `kn` but code only handled `kt`. This PR adds `kn` support.