### PR TITLE
Allow any positive integer for label_spacing and num_segments

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,10 +5,13 @@ module.exports = {
         sourceType: "module" // Allows for the use of imports
     },
     extends: [
+        "eslint:recommended",
         "plugin:@typescript-eslint/recommended" // Uses the recommended rules from the @typescript-eslint/eslint-plugin
     ],
     rules: {
         // Place to specify ESLint rules. Can be used to overwrite rules specified from the extended configs
         // e.g. "@typescript-eslint/explicit-function-return-type": "off",
+        "eqeqeq": "error",
+        "space-infix-ops": "error"
     }
 };

--- a/cypress/e2e/config.cy.ts
+++ b/cypress/e2e/config.cy.ts
@@ -4,14 +4,14 @@ describe('Config', () => {
   beforeEach(() => {
     cy.visitHarness();
   });
-  it('errors for num_segments < 2', () => {
+  it('errors for num_segments < 1', () => {
     cy.configure({
-      num_segments: '1'
+      num_segments: '0'
     });
     cy.get('hui-error-card')
       .shadow()
       .find('p')
-      .should('have.text', 'num_segments must be an even integer greater than or equal to 2');
+      .should('have.text', 'Must be a positive integer');
   });
   it('errors for offset < 0', () => {
     cy.configure({
@@ -330,7 +330,7 @@ describe('Config', () => {
       cy.get('weather-bar')
         .shadow()
         .find('div.axes > div.bar-block')
-        .should('have.length', 5);
+        .should('have.length', 10);
       cy.window()
         .then(win => {
           // @ts-expect-error accessing hourlyWeather global
@@ -379,7 +379,7 @@ describe('Config', () => {
         .shadow()
         .find('div.axes > div.bar-block div.temperature')
         .first()
-        .should('have.text', '84°');
+        .should('have.text', '85°');
       cy.window()
         .then(win => {
           // @ts-expect-error accessing hourlyWeather global

--- a/cypress/e2e/internationalization.cy.ts
+++ b/cypress/e2e/internationalization.cy.ts
@@ -10,7 +10,7 @@ describe('Internationalization', () => {
       .shadow()
       .find('div.axes > div.bar-block div.hour')
       .first()
-      .should('have.text', '6 PM');
+      .should('have.text', '5 PM');
   });
 
   it('formats times correctly for 24 hour', () => {
@@ -24,7 +24,7 @@ describe('Internationalization', () => {
       .shadow()
       .find('div.axes > div.bar-block div.hour')
       .first()
-      .should('have.text', '18:00');
+      .should('have.text', '17:00');
   });
 
   it('defaults to 12 hour for en', () => {
@@ -38,7 +38,7 @@ describe('Internationalization', () => {
       .shadow()
       .find('div.axes > div.bar-block div.hour')
       .first()
-      .should('have.text', '6 PM');
+      .should('have.text', '5 PM');
   });
 
   it('defaults to 24 hour for fr', () => {
@@ -52,7 +52,7 @@ describe('Internationalization', () => {
       .shadow()
       .find('div.axes > div.bar-block div.hour')
       .first()
-      .should('have.text', '18:00');
+      .should('have.text', '17:00');
   });
 
   describe('Number formatting', () => {
@@ -145,7 +145,7 @@ describe('Internationalization', () => {
         .shadow()
         .find('div.axes > div.bar-block div.temperature')
         .first()
-        .should('have.text', '85.5°');
+        .should('have.text', '84.2°');
     });
     it('uses comma as decimal separator when specified as decimal_comma', () => {
       cy.setLocale({
@@ -155,7 +155,7 @@ describe('Internationalization', () => {
         .shadow()
         .find('div.axes > div.bar-block div.temperature')
         .first()
-        .should('have.text', '85,5°');
+        .should('have.text', '84,2°');
     });
     it('uses comma as decimal separator when specified as space_comma', () => {
       cy.setLocale({
@@ -165,7 +165,7 @@ describe('Internationalization', () => {
         .shadow()
         .find('div.axes > div.bar-block div.temperature')
         .first()
-        .should('have.text', '85,5°');
+        .should('have.text', '84,2°');
     });
   });
 });

--- a/cypress/e2e/weather-bar.cy.ts
+++ b/cypress/e2e/weather-bar.cy.ts
@@ -222,25 +222,22 @@ describe('Weather bar', () => {
     });
 
     const expectedHours = [
-      '6 PM',
-      '8 PM',
-      '10 PM',
-      '12 AM',
-      '2 AM',
-      '4 AM'
+      '5 PM',
+      '7 PM',
+      '9 PM',
+      '11 PM',
+      '1 AM',
+      '3 AM'
     ];
 
     it('shows hour labels on axes', () => {
-      cy.configure({
-        offset: '1'
-      });
       cy.get('weather-bar')
         .shadow()
         .find('div.axes > div.bar-block div.hour')
         .should('have.length', 12)
         .each((el, i) => {
-          if (i%2 == 0) {
-            cy.wrap(el).should('have.text', expectedHours[i/2]);
+          if (i % 2 === 0) {
+            cy.wrap(el).should('have.text', expectedHours[i / 2]);
           }
         });
     });
@@ -318,31 +315,28 @@ describe('Weather bar', () => {
     });
 
     const expectedTemperatures = [
+      84,
       85,
       84,
-      83,
-      75,
-      67,
-      64
+      79,
+      70,
+      65
     ];
 
     it('shows temperature labels on axes', () => {
-      cy.configure({
-        offset: '1'
-      });
       cy.get('weather-bar')
         .shadow()
         .find('div.axes > div.bar-block div.temperature')
         .should('have.length', 12)
         .each((el, i) => {
-          if (i%2 == 0) {
-            cy.wrap(el).should('have.text', expectedTemperatures[i/2] + '°');
+          if (i % 2 === 0) {
+            cy.wrap(el).should('have.text', expectedTemperatures[i / 2] + '°');
           }
         });
     });
     it('respects offset when specified config', () => {
       cy.configure({
-        offset: '3',
+        offset: '2',
         num_segments: '10'
       });
       cy.get('weather-bar')
@@ -350,8 +344,8 @@ describe('Weather bar', () => {
         .find('div.axes > div.bar-block div.temperature')
         .should('have.length', 10)
         .each((el, i) => {
-          if (i%2 == 0) {
-            cy.wrap(el).should('have.text', expectedTemperatures[i/2 + 1] + '°');
+          if (i % 2 === 0) {
+            cy.wrap(el).should('have.text', expectedTemperatures[i / 2 + 1] + '°');
           }
         });
     });
@@ -391,82 +385,78 @@ describe('Weather bar', () => {
     });
 
     const expectedWindSpeeds = [
-      6,
-      6,
       5,
+      6,
+      6,
       6,
       4,
       4
     ];
     const expectedWindDirections = [
       'WSW',
-      'W',
+      'WSW',
       'WNW',
-      'N',
+      'NW',
       'WNW',
       'WNW'
     ];
     const expectedWindBearings = [
-      253,
-      278,
-      293,
-      359,
-      285,
-      283
+      255,
+      258,
+      297,
+      304,
+      290,
+      285
     ];
 
     it('shows wind speed/direction if specified in config', () => {
       cy.configure({
-        show_wind: 'true',
-        offset: '1',
+        show_wind: 'true'
       });
       cy.get('weather-bar')
         .shadow()
         .find('div.axes > div.bar-block div.wind')
         .should('have.length', 12)
         .each((el, i) => {
-          if (i%2 == 0) {
-            cy.wrap(el).should('have.text', `${expectedWindSpeeds[i/2]} mph${expectedWindDirections[i/2]}`);
+          if (i % 2 === 0) {
+            cy.wrap(el).should('have.text', `${expectedWindSpeeds[i / 2]} mph${expectedWindDirections[i / 2]}`);
           }
         });
     });
 
     it('shows wind speed if specified in config', () => {
       cy.configure({
-        show_wind: 'speed',
-        offset: '1',
+        show_wind: 'speed'
       });
       cy.get('weather-bar')
         .shadow()
         .find('div.axes > div.bar-block div.wind')
         .should('have.length', 12)
         .each((el, i) => {
-          if (i%2 == 0) {
-            cy.wrap(el).should('have.text', `${expectedWindSpeeds[i/2]} mph`);
+          if (i % 2 === 0) {
+            cy.wrap(el).should('have.text', `${expectedWindSpeeds[i / 2]} mph`);
           }
         });
     });
 
     it('shows wind direction if specified in config', () => {
       cy.configure({
-        show_wind: 'direction',
-        offset: '1',
+        show_wind: 'direction'
       });
       cy.get('weather-bar')
         .shadow()
         .find('div.axes > div.bar-block div.wind')
         .should('have.length', 12)
         .each((el, i) => {
-          if (i%2 == 0) {
-            cy.wrap(el).should('have.text', `${expectedWindDirections[i/2]}`);
+          if (i % 2 === 0) {
+            cy.wrap(el).should('have.text', `${expectedWindDirections[i / 2]}`);
           }
         });
     });
 
     it('shows wind barbs if specified in config', () => {
       cy.configure({
-        show_wind: 'barb',
-        offset: '1',
+        show_wind: 'barb'
       });
       cy.get('weather-bar')
         .shadow()
@@ -481,16 +471,15 @@ describe('Weather bar', () => {
 
     it('shows wind barbs along with speed if specified in config', () => {
       cy.configure({
-        show_wind: 'barb-and-speed',
-        offset: '1',
+        show_wind: 'barb-and-speed'
       });
       cy.get('weather-bar')
         .shadow()
         .find('div.axes > div.bar-block div.wind')
         .should('have.length', 12)
         .each((el, i) => {
-          if (i%2 == 0) {
-            cy.wrap(el).should('contain.text', `${expectedWindSpeeds[i/2]}`);
+          if (i % 2 === 0) {
+            cy.wrap(el).should('contain.text', `${expectedWindSpeeds[i / 2]}`);
           }
         })
         .find('span')
@@ -503,16 +492,15 @@ describe('Weather bar', () => {
 
     it('shows wind barbs along with direction if specified in config', () => {
       cy.configure({
-        show_wind: 'barb-and-direction',
-        offset: '1',
+        show_wind: 'barb-and-direction'
       });
       cy.get('weather-bar')
         .shadow()
         .find('div.axes > div.bar-block div.wind')
         .should('have.length', 12)
         .each((el, i) => {
-          if (i%2 == 0) {
-            cy.wrap(el).should('contain.text', `${expectedWindDirections[i/2]}`);
+          if (i % 2 === 0) {
+            cy.wrap(el).should('contain.text', `${expectedWindDirections[i / 2]}`);
           }
         })
         .find('span')
@@ -525,16 +513,15 @@ describe('Weather bar', () => {
 
     it('shows wind barbs along with speed and direction if specified in config', () => {
       cy.configure({
-        show_wind: 'barb-speed-and-direction',
-        offset: '1',
+        show_wind: 'barb-speed-and-direction'
       });
       cy.get('weather-bar')
         .shadow()
         .find('div.axes > div.bar-block div.wind')
         .should('have.length', 12)
         .each((el, i) => {
-          if (i%2 == 0) {
-            cy.wrap(el).should('contain.text', `${expectedWindSpeeds[i/2]} mph${expectedWindDirections[i/2]}`);
+          if (i % 2 === 0) {
+            cy.wrap(el).should('contain.text', `${expectedWindSpeeds[i / 2]} mph${expectedWindDirections[i / 2]}`);
           }
         })
         .find('span')
@@ -566,8 +553,8 @@ describe('Weather bar', () => {
                 "precipitation": 0.35,
                 "precipitation_probability": 0,
                 "pressure": 1007,
-                "wind_speed": 6.07,
-                "wind_bearing": 'WSW',
+                "wind_speed": 6.16,
+                "wind_bearing": 'W',
                 "condition": "cloudy",
                 "clouds": 75,
                 "temperature": 85
@@ -577,8 +564,8 @@ describe('Weather bar', () => {
                 "precipitation": 0,
                 "precipitation_probability": 0,
                 "pressure": 1007,
-                "wind_speed": 6.16,
-                "wind_bearing": 'W',
+                "wind_speed": 6.07,
+                "wind_bearing": 'WSW',
                 "condition": "cloudy",
                 "clouds": 60,
                 "temperature": 85
@@ -635,8 +622,7 @@ describe('Weather bar', () => {
       cy.configure({
         entity: 'weather.wind_bearing_string',
         num_segments: '6',
-        show_wind: 'direction',
-        offset: '1'
+        show_wind: 'direction'
       });
 
       cy.get('weather-bar')
@@ -644,8 +630,8 @@ describe('Weather bar', () => {
         .find('div.axes > div.bar-block div.wind')
         .should('have.length', 6)
         .each((el, i) => {
-          if (i%2 == 0) {
-            cy.wrap(el).should('have.text', `${expectedWindDirections[i/2]}`);
+          if (i % 2 === 0) {
+            cy.wrap(el).should('have.text', `${expectedWindDirections[i / 2]}`);
           }
         });
     });
@@ -741,8 +727,7 @@ describe('Weather bar', () => {
         entity: 'weather.wind_bearing_string',
         num_segments: '6',
         show_wind: 'direction',
-        language: 'nl',
-        offset: '1'
+        language: 'nl'
       });
 
       const expectedDutchWindDirections = [
@@ -756,8 +741,8 @@ describe('Weather bar', () => {
         .find('div.axes > div.bar-block div.wind')
         .should('have.length', 6)
         .each((el, i) => {
-          if (i%2 == 0) {
-            cy.wrap(el).should('have.text', `${expectedDutchWindDirections[i/2]}`);
+          if (i % 2 === 0) {
+            cy.wrap(el).should('have.text', `${expectedDutchWindDirections[i / 2]}`);
           }
         });
     });
@@ -853,8 +838,7 @@ describe('Weather bar', () => {
         entity: 'weather.wind_bearing_string',
         num_segments: '6',
         show_wind: 'direction',
-        language: 'nl',
-        offset: '1'
+        language: 'nl'
       });
 
       const expectedFakeWindDirections = [
@@ -868,8 +852,8 @@ describe('Weather bar', () => {
         .find('div.axes > div.bar-block div.wind')
         .should('have.length', 6)
         .each((el, i) => {
-          if (i%2 == 0) {
-            cy.wrap(el).should('have.text', `${expectedFakeWindDirections[i/2]}`);
+          if (i % 2 === 0) {
+            cy.wrap(el).should('have.text', `${expectedFakeWindDirections[i / 2]}`);
           }
         });
     });
@@ -895,19 +879,18 @@ describe('Weather bar', () => {
 
     it('shows precipitation if specified in config', () => {
       cy.configure({
-        show_precipitation_amounts: true,
-        offset: '1'
+        show_precipitation_amounts: true
       });
       cy.get('weather-bar')
         .shadow()
         .find('div.axes > div.bar-block div.precipitation')
         .should('have.length', 12)
         .each((el, i) => {
-          if (i%2 == 0) {
-            if (expectedPrecipitation[i/2] === 0) {
+          if (i % 2 === 0) {
+            if (expectedPrecipitation[i / 2] === 0) {
               cy.wrap(el).should('be.empty');
             } else {
-              cy.wrap(el).should('have.text', `${expectedPrecipitation[i/2]} in`);
+              cy.wrap(el).should('have.text', `${expectedPrecipitation[i / 2]} in`);
             }
           }
         });
@@ -924,21 +907,20 @@ describe('Weather bar', () => {
 
     it('shows precipitation probability if specified in config', () => {
       cy.configure({
-        show_precipitation_probability: true,
-        offset: '1',
+        show_precipitation_probability: true
       });
       cy.get('weather-bar')
         .shadow()
         .find('div.axes > div.bar-block div.precipitation')
         .should('have.length', 12)
         .each((el, i) => {
-          if (i%2 == 0) {
-            if (expectedPrecipitationProbability[i/2] === 0) {
+          if (i % 2 === 0) {
+            if (expectedPrecipitationProbability[i / 2] === 0) {
               cy.wrap(el.text()).should('be.empty');
             } else {
-              cy.wrap(el).should('have.text', `${expectedPrecipitationProbability[i/2]}%`)
+              cy.wrap(el).should('have.text', `${expectedPrecipitationProbability[i / 2]}%`)
                 .find('span')
-                .should('have.attr', 'title', `${expectedPrecipitationProbability[i/2]}% chance of precipitation`);
+                .should('have.attr', 'title', `${expectedPrecipitationProbability[i / 2]}% chance of precipitation`);
             }
           }
         });

--- a/cypress/e2e/weather-bar.cy.ts
+++ b/cypress/e2e/weather-bar.cy.ts
@@ -47,10 +47,10 @@ describe('Weather bar', () => {
   });
 
   const expectedWidths = [
-    3,
-    3,
-    5,
-    1
+    6,
+    6,
+    10,
+    2
   ];
   const expectedColors = [
     'rgb(119, 119, 119)',
@@ -218,7 +218,7 @@ describe('Weather bar', () => {
       cy.get('weather-bar')
         .shadow()
         .find('div.axes > div.bar-block')
-        .should('have.length', 6);
+        .should('have.length', 12);
     });
 
     const expectedHours = [
@@ -231,12 +231,17 @@ describe('Weather bar', () => {
     ];
 
     it('shows hour labels on axes', () => {
+      cy.configure({
+        offset: '1'
+      });
       cy.get('weather-bar')
         .shadow()
         .find('div.axes > div.bar-block div.hour')
-        .should('have.length', 6)
+        .should('have.length', 12)
         .each((el, i) => {
-          cy.wrap(el).should('have.text', expectedHours[i]);
+          if (i%2 == 0) {
+            cy.wrap(el).should('have.text', expectedHours[i/2]);
+          }
         });
     });
     it('hides hours when specified in config', () => {
@@ -246,7 +251,7 @@ describe('Weather bar', () => {
       cy.get('weather-bar')
         .shadow()
         .find('div.axes > div.bar-block div.hour')
-        .should('have.length', 6)
+        .should('have.length', 12)
         .each((el) => {
           cy.wrap(el).should('be.empty');
         });
@@ -261,11 +266,11 @@ describe('Weather bar', () => {
 
     const expectedDates = [
       'Jul 21',
+      'Jul 21',
       'Jul 22',
       'Jul 22',
       'Jul 22',
-      'Jul 22',
-      'Jul 23'
+      'Jul 22'
     ];
 
     it('shows all date labels on axes when specified in config', () => {
@@ -296,7 +301,8 @@ describe('Weather bar', () => {
       cy.configure({
         show_date: 'boundary',
         label_spacing: '6',
-        num_segments: '32'
+        num_segments: '32',
+        offset: '1'
       });
       cy.get('weather-bar')
         .shadow()
@@ -321,25 +327,32 @@ describe('Weather bar', () => {
     ];
 
     it('shows temperature labels on axes', () => {
+      cy.configure({
+        offset: '1'
+      });
       cy.get('weather-bar')
         .shadow()
         .find('div.axes > div.bar-block div.temperature')
-        .should('have.length', 6)
+        .should('have.length', 12)
         .each((el, i) => {
-          cy.wrap(el).should('have.text', expectedTemperatures[i] + '°');
+          if (i%2 == 0) {
+            cy.wrap(el).should('have.text', expectedTemperatures[i/2] + '°');
+          }
         });
     });
     it('respects offset when specified config', () => {
       cy.configure({
-        offset: '2',
+        offset: '3',
         num_segments: '10'
       });
       cy.get('weather-bar')
         .shadow()
         .find('div.axes > div.bar-block div.temperature')
-        .should('have.length', 5)
+        .should('have.length', 10)
         .each((el, i) => {
-          cy.wrap(el).should('have.text', expectedTemperatures[i + 1] + '°');
+          if (i%2 == 0) {
+            cy.wrap(el).should('have.text', expectedTemperatures[i/2 + 1] + '°');
+          }
         });
     });
     it('hides temperatures when specified in config', () => {
@@ -349,7 +362,7 @@ describe('Weather bar', () => {
       cy.get('weather-bar')
         .shadow()
         .find('div.axes > div.bar-block div.temperature')
-        .should('have.length', 6)
+        .should('have.length', 12)
         .each((el) => {
           cy.wrap(el).should('be.empty');
         });
@@ -371,7 +384,7 @@ describe('Weather bar', () => {
       cy.get('weather-bar')
         .shadow()
         .find('div.axes > div.bar-block div.wind')
-        .should('have.length', 6)
+        .should('have.length', 12)
         .each((el) => {
           cy.wrap(el).should('be.empty');
         });
@@ -404,46 +417,56 @@ describe('Weather bar', () => {
 
     it('shows wind speed/direction if specified in config', () => {
       cy.configure({
-        show_wind: 'true'
+        show_wind: 'true',
+        offset: '1',
       });
       cy.get('weather-bar')
         .shadow()
         .find('div.axes > div.bar-block div.wind')
-        .should('have.length', 6)
+        .should('have.length', 12)
         .each((el, i) => {
-          cy.wrap(el).should('have.text', `${expectedWindSpeeds[i]} mph${expectedWindDirections[i]}`);
+          if (i%2 == 0) {
+            cy.wrap(el).should('have.text', `${expectedWindSpeeds[i/2]} mph${expectedWindDirections[i/2]}`);
+          }
         });
     });
 
     it('shows wind speed if specified in config', () => {
       cy.configure({
-        show_wind: 'speed'
+        show_wind: 'speed',
+        offset: '1',
       });
       cy.get('weather-bar')
         .shadow()
         .find('div.axes > div.bar-block div.wind')
-        .should('have.length', 6)
+        .should('have.length', 12)
         .each((el, i) => {
-          cy.wrap(el).should('have.text', `${expectedWindSpeeds[i]} mph`);
+          if (i%2 == 0) {
+            cy.wrap(el).should('have.text', `${expectedWindSpeeds[i/2]} mph`);
+          }
         });
     });
 
     it('shows wind direction if specified in config', () => {
       cy.configure({
-        show_wind: 'direction'
+        show_wind: 'direction',
+        offset: '1',
       });
       cy.get('weather-bar')
         .shadow()
         .find('div.axes > div.bar-block div.wind')
-        .should('have.length', 6)
+        .should('have.length', 12)
         .each((el, i) => {
-          cy.wrap(el).should('have.text', `${expectedWindDirections[i]}`);
+          if (i%2 == 0) {
+            cy.wrap(el).should('have.text', `${expectedWindDirections[i/2]}`);
+          }
         });
     });
 
     it('shows wind barbs if specified in config', () => {
       cy.configure({
-        show_wind: 'barb'
+        show_wind: 'barb',
+        offset: '1',
       });
       cy.get('weather-bar')
         .shadow()
@@ -458,14 +481,17 @@ describe('Weather bar', () => {
 
     it('shows wind barbs along with speed if specified in config', () => {
       cy.configure({
-        show_wind: 'barb-and-speed'
+        show_wind: 'barb-and-speed',
+        offset: '1',
       });
       cy.get('weather-bar')
         .shadow()
         .find('div.axes > div.bar-block div.wind')
-        .should('have.length', 6)
+        .should('have.length', 12)
         .each((el, i) => {
-          cy.wrap(el).should('contain.text', `${expectedWindSpeeds[i]}`);
+          if (i%2 == 0) {
+            cy.wrap(el).should('contain.text', `${expectedWindSpeeds[i/2]}`);
+          }
         })
         .find('span')
         .each((el, i) => {
@@ -477,14 +503,17 @@ describe('Weather bar', () => {
 
     it('shows wind barbs along with direction if specified in config', () => {
       cy.configure({
-        show_wind: 'barb-and-direction'
+        show_wind: 'barb-and-direction',
+        offset: '1',
       });
       cy.get('weather-bar')
         .shadow()
         .find('div.axes > div.bar-block div.wind')
-        .should('have.length', 6)
+        .should('have.length', 12)
         .each((el, i) => {
-          cy.wrap(el).should('contain.text', `${expectedWindDirections[i]}`);
+          if (i%2 == 0) {
+            cy.wrap(el).should('contain.text', `${expectedWindDirections[i/2]}`);
+          }
         })
         .find('span')
         .each((el, i) => {
@@ -496,14 +525,17 @@ describe('Weather bar', () => {
 
     it('shows wind barbs along with speed and direction if specified in config', () => {
       cy.configure({
-        show_wind: 'barb-speed-and-direction'
+        show_wind: 'barb-speed-and-direction',
+        offset: '1',
       });
       cy.get('weather-bar')
         .shadow()
         .find('div.axes > div.bar-block div.wind')
-        .should('have.length', 6)
+        .should('have.length', 12)
         .each((el, i) => {
-          cy.wrap(el).should('contain.text', `${expectedWindSpeeds[i]} mph${expectedWindDirections[i]}`);
+          if (i%2 == 0) {
+            cy.wrap(el).should('contain.text', `${expectedWindSpeeds[i/2]} mph${expectedWindDirections[i/2]}`);
+          }
         })
         .find('span')
         .each((el, i) => {
@@ -583,6 +615,17 @@ describe('Weather bar', () => {
                 "condition": "partlycloudy",
                 "clouds": 19,
                 "temperature": 83
+              },
+              {
+                "datetime": "2022-07-21T23:00:00+00:00",
+                "precipitation": 0,
+                "precipitation_probability": 1,
+                "pressure": 1008,
+                "wind_speed": 6.39,
+                "wind_bearing": 'NW',
+                "condition": "sunny",
+                "clouds": 4,
+                "temperature": 79
               }
             ]
           }
@@ -592,15 +635,18 @@ describe('Weather bar', () => {
       cy.configure({
         entity: 'weather.wind_bearing_string',
         num_segments: '6',
-        show_wind: 'direction'
+        show_wind: 'direction',
+        offset: '1'
       });
 
       cy.get('weather-bar')
         .shadow()
         .find('div.axes > div.bar-block div.wind')
-        .should('have.length', 3)
+        .should('have.length', 6)
         .each((el, i) => {
-          cy.wrap(el).should('have.text', `${expectedWindDirections[i]}`);
+          if (i%2 == 0) {
+            cy.wrap(el).should('have.text', `${expectedWindDirections[i/2]}`);
+          }
         });
     });
 
@@ -674,6 +720,17 @@ describe('Weather bar', () => {
                 "condition": "partlycloudy",
                 "clouds": 19,
                 "temperature": 83
+              },
+              {
+                "datetime": "2022-07-21T23:00:00+00:00",
+                "precipitation": 0,
+                "precipitation_probability": 1,
+                "pressure": 1008,
+                "wind_speed": 6.39,
+                "wind_bearing": 'NW',
+                "condition": "sunny",
+                "clouds": 4,
+                "temperature": 79
               }
             ]
           }
@@ -684,7 +741,8 @@ describe('Weather bar', () => {
         entity: 'weather.wind_bearing_string',
         num_segments: '6',
         show_wind: 'direction',
-        language: 'nl'
+        language: 'nl',
+        offset: '1'
       });
 
       const expectedDutchWindDirections = [
@@ -696,9 +754,11 @@ describe('Weather bar', () => {
       cy.get('weather-bar')
         .shadow()
         .find('div.axes > div.bar-block div.wind')
-        .should('have.length', 3)
+        .should('have.length', 6)
         .each((el, i) => {
-          cy.wrap(el).should('have.text', `${expectedDutchWindDirections[i]}`);
+          if (i%2 == 0) {
+            cy.wrap(el).should('have.text', `${expectedDutchWindDirections[i/2]}`);
+          }
         });
     });
 
@@ -772,6 +832,17 @@ describe('Weather bar', () => {
                 "condition": "partlycloudy",
                 "clouds": 19,
                 "temperature": 83
+              },
+              {
+                "datetime": "2022-07-21T23:00:00+00:00",
+                "precipitation": 0,
+                "precipitation_probability": 1,
+                "pressure": 1008,
+                "wind_speed": 6.39,
+                "wind_bearing": 'JKL',
+                "condition": "sunny",
+                "clouds": 4,
+                "temperature": 79
               }
             ]
           }
@@ -782,7 +853,8 @@ describe('Weather bar', () => {
         entity: 'weather.wind_bearing_string',
         num_segments: '6',
         show_wind: 'direction',
-        language: 'nl'
+        language: 'nl',
+        offset: '1'
       });
 
       const expectedFakeWindDirections = [
@@ -794,9 +866,11 @@ describe('Weather bar', () => {
       cy.get('weather-bar')
         .shadow()
         .find('div.axes > div.bar-block div.wind')
-        .should('have.length', 3)
+        .should('have.length', 6)
         .each((el, i) => {
-          cy.wrap(el).should('have.text', `${expectedFakeWindDirections[i]}`);
+          if (i%2 == 0) {
+            cy.wrap(el).should('have.text', `${expectedFakeWindDirections[i/2]}`);
+          }
         });
     });
 
@@ -804,7 +878,7 @@ describe('Weather bar', () => {
       cy.get('weather-bar')
         .shadow()
         .find('div.axes > div.bar-block div.precipitation')
-        .should('have.length', 6)
+        .should('have.length', 12)
         .each((el) => {
           cy.wrap(el).should('be.empty');
         });
@@ -821,17 +895,20 @@ describe('Weather bar', () => {
 
     it('shows precipitation if specified in config', () => {
       cy.configure({
-        show_precipitation_amounts: true
+        show_precipitation_amounts: true,
+        offset: '1'
       });
       cy.get('weather-bar')
         .shadow()
         .find('div.axes > div.bar-block div.precipitation')
-        .should('have.length', 6)
+        .should('have.length', 12)
         .each((el, i) => {
-          if (expectedPrecipitation[i] === 0) {
-            cy.wrap(el).should('be.empty');
-          } else {
-            cy.wrap(el).should('have.text', `${expectedPrecipitation[i]} in`);
+          if (i%2 == 0) {
+            if (expectedPrecipitation[i/2] === 0) {
+              cy.wrap(el).should('be.empty');
+            } else {
+              cy.wrap(el).should('have.text', `${expectedPrecipitation[i/2]} in`);
+            }
           }
         });
     });
@@ -847,19 +924,22 @@ describe('Weather bar', () => {
 
     it('shows precipitation probability if specified in config', () => {
       cy.configure({
-        show_precipitation_probability: true
+        show_precipitation_probability: true,
+        offset: '1',
       });
       cy.get('weather-bar')
         .shadow()
         .find('div.axes > div.bar-block div.precipitation')
-        .should('have.length', 6)
+        .should('have.length', 12)
         .each((el, i) => {
-          if (expectedPrecipitationProbability[i] === 0) {
-            cy.wrap(el.text()).should('be.empty');
-          } else {
-            cy.wrap(el).should('have.text', `${expectedPrecipitationProbability[i]}%`)
-              .find('span')
-              .should('have.attr', 'title', `${expectedPrecipitationProbability[i]}% chance of precipitation`);
+          if (i%2 == 0) {
+            if (expectedPrecipitationProbability[i/2] === 0) {
+              cy.wrap(el.text()).should('be.empty');
+            } else {
+              cy.wrap(el).should('have.text', `${expectedPrecipitationProbability[i/2]}%`)
+                .find('span')
+                .should('have.attr', 'title', `${expectedPrecipitationProbability[i/2]}% chance of precipitation`);
+            }
           }
         });
     });

--- a/cypress/fixtures/harness.html
+++ b/cypress/fixtures/harness.html
@@ -39,8 +39,8 @@
             forecast: [
             {
               "datetime": "2022-07-21T17:00:00+00:00",
-              "precipitation": 0,
-              "precipitation_probability": 0,
+              "precipitation": 0.35,
+              "precipitation_probability": 75,
               "pressure": 1007,
               "wind_speed": 4.67,
               "wind_bearing": 255,
@@ -61,8 +61,8 @@
             },
             {
               "datetime": "2022-07-21T19:00:00+00:00",
-              "precipitation": 0,
-              "precipitation_probability": 0,
+              "precipitation": 1.3,
+              "precipitation_probability": 100,
               "pressure": 1007,
               "wind_speed": 6.16,
               "wind_bearing": 258,
@@ -84,7 +84,7 @@
             {
               "datetime": "2022-07-21T21:00:00+00:00",
               "precipitation": 0,
-              "precipitation_probability": 1,
+              "precipitation_probability": 15,
               "pressure": 1007,
               "wind_speed": 5.78,
               "wind_bearing": 297,
@@ -106,7 +106,7 @@
             {
               "datetime": "2022-07-21T23:00:00+00:00",
               "precipitation": 0,
-              "precipitation_probability": 1,
+              "precipitation_probability": 0,
               "pressure": 1008,
               "wind_speed": 6.39,
               "wind_bearing": 304,
@@ -128,7 +128,7 @@
             {
               "datetime": "2022-07-22T01:00:00+00:00",
               "precipitation": 0,
-              "precipitation_probability": 0,
+              "precipitation_probability": 5,
               "pressure": 1009,
               "wind_speed": 3.95,
               "wind_bearing": 290,

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -112,11 +112,11 @@ export class HourlyWeatherCardEditor extends ScopedRegistryHost(LitElement) impl
         .configValue=${'num_segments'}
         @input=${this._valueChanged}
         .type=${'number'}
-        .min=${2}
-        .step=${2}
-        .pattern=${"([1-9][0-9]*[02468])|([2468])"}
+        .min=${1}
+        .step=${1}
+        .pattern=${"[1-9][0-9]*"}
         .autoValidate=${true}
-        validationMessage=${localize('errors.must_be_int')}
+        validationMessage=${localize('errors.must_be_positive_int')}
       ></mwc-textfield>
       <mwc-textfield
       label=${localize('editor.offset')}
@@ -134,11 +134,11 @@ export class HourlyWeatherCardEditor extends ScopedRegistryHost(LitElement) impl
         .configValue=${'label_spacing'}
         @input=${this._valueChanged}
         .type=${'number'}
-        .min=${2}
-        .step=${2}
-        .pattern=${"([1-9][0-9]*[02468])|([2468])"}
+        .min=${1}
+        .step=${1}
+        .pattern=${"[1-9][0-9]*"}
         .autoValidate=${true}
-        validationMessage=${localize('errors.must_be_int')}
+        validationMessage=${localize('errors.must_be_positive_int')}
       ></mwc-textfield>
       <mwc-formfield .label=${localize('editor.icons')}>
         <mwc-switch

--- a/src/hourly-weather.ts
+++ b/src/hourly-weather.ts
@@ -139,8 +139,8 @@ export class HourlyWeatherCard extends LitElement {
 
     if (config.label_spacing) {
       const numLabelSpacing = parseInt(config.label_spacing, 10);
-      if (!Number.isNaN(numLabelSpacing) && (numLabelSpacing < 2 || numLabelSpacing % 2 !== 0)) {
-        throw new Error(this.localize('errors.label_spacing_positive_even_int'));
+      if (!Number.isNaN(numLabelSpacing) && (numLabelSpacing < 1)) {
+        throw new Error(this.localize('errors.must_be_positive_int'));
       }
     }
 
@@ -241,9 +241,9 @@ export class HourlyWeatherCard extends LitElement {
     const labelSpacing = parseInt(config.label_spacing ?? '2', 10);
     const forecastNotAvailable = !forecast || !forecast.length;
 
-    if (numSegments < 2) {
+    if (numSegments < 1) {
       // REMARK: Ok, so I'm re-using a localized string here. Probably not the best, but it avoids repeating for no good reason
-      return await this._showError(this.localize('errors.label_spacing_positive_even_int', 'label_spacing', 'num_segments'));
+      return await this._showError(this.localize('errors.must_be_positive_int', 'label_spacing', 'num_segments'));
     }
 
     if (offset < 0) {
@@ -254,8 +254,8 @@ export class HourlyWeatherCard extends LitElement {
       return await this._showError(this.localize('errors.too_many_segments_requested'));
     }
 
-    if (labelSpacing < 2 || labelSpacing % 2 !== 0) {
-      return await this._showError(this.localize('errors.label_spacing_positive_even_int'));
+    if (labelSpacing < 1) {
+      return await this._showError(this.localize('errors.must_be_positive_int'));
     }
 
     if (config.show_wind?.includes('barb') && typeof forecast[0].wind_bearing === 'string') {

--- a/src/weather-bar.ts
+++ b/src/weather-bar.ts
@@ -65,7 +65,7 @@ export class WeatherBar extends LitElement {
         let icon = ICONS[cond[0]];
         if (icon === cond[0]) icon = 'mdi:weather-' + icon;
         else icon = 'mdi:' + icon;
-        const barStyles: Readonly<StyleInfo> = { gridColumnStart: String(gridStart), gridColumnEnd: String(gridStart += cond[1]*2) };
+        const barStyles: Readonly<StyleInfo> = { gridColumnStart: String(gridStart), gridColumnEnd: String(gridStart += cond[1] * 2) };
         conditionBars.push(html`
           <div class=${cond[0]} style=${styleMap(barStyles)} data-tippy-content=${label}>
             ${this.icons ?

--- a/src/weather-bar.ts
+++ b/src/weather-bar.ts
@@ -65,7 +65,7 @@ export class WeatherBar extends LitElement {
         let icon = ICONS[cond[0]];
         if (icon === cond[0]) icon = 'mdi:weather-' + icon;
         else icon = 'mdi:' + icon;
-        const barStyles: Readonly<StyleInfo> = { gridColumnStart: String(gridStart), gridColumnEnd: String(gridStart += cond[1]) };
+        const barStyles: Readonly<StyleInfo> = { gridColumnStart: String(gridStart), gridColumnEnd: String(gridStart += cond[1]*2) };
         conditionBars.push(html`
           <div class=${cond[0]} style=${styleMap(barStyles)} data-tippy-content=${label}>
             ${this.icons ?
@@ -79,8 +79,8 @@ export class WeatherBar extends LitElement {
     const windCfg = this.show_wind ?? '';
     const barBlocks: TemplateResult[] = [];
     let lastDate: string | null = null;
-    for (let i = 1; i < this.temperatures.length; i += 2) {
-      const skipLabel = (i - 1) % this.label_spacing !== 0;
+    for (let i = 0; i < this.temperatures.length; i += 1) {
+      const skipLabel = i % (this.label_spacing) !== 0;
       const hideHours = this.hide_hours || skipLabel;
       const hideTemperature = this.hide_temperatures || skipLabel;
       const showWindSpeed = (windCfg === 'true' || windCfg.includes('speed')) && !skipLabel;
@@ -316,13 +316,10 @@ export class WeatherBar extends LitElement {
     .bar-block-left {
       grid-area: left;
       border: 1px solid var(--divider-color, lightgray);
-      border-width: 0 1px;
+      border-width: 0 1px 0 0;
     }
     .bar-block-right {
       grid-area: right;
-    }
-    .bar-block:last-child .bar-block-right {
-      border-right: 1px solid var(--divider-color, lightgray);
     }
     .bar-block-bottom {
       text-align: center;


### PR DESCRIPTION
This PR fixes #427. The solution is based on the proposed solution in https://github.com/decompil3d/lovelace-hourly-weather/issues/427#issuecomment-1626106687. However, instead of specifically checking for a label_spacing of 1 and changing the behavior, it always creates 2 columns in the grid for each label and shows the tick bar at the center. This removes the need for even numbers in label_spacing and num_segments.

The change also means that the data in the bar is now centered around its corresponding label, instead of trailing it. Here's an example from my dashboard:
![image](https://github.com/decompil3d/lovelace-hourly-weather/assets/7600867/ab646954-2997-4829-836d-2a26e9199248)

I've adjusted the tests so they pass, but its a quick and dirty solution (e.g. I've added offset: '1' to most tests, since the new code now shows the data starting at the first label). The tests may need to be improved and expanded to test for odd label_spacing and num_segments values.
