### PR TITLE
Bugfix: Double the tick width to make it visible on small displays (like in 4.x)

### DIFF
--- a/src/weather-bar.ts
+++ b/src/weather-bar.ts
@@ -320,6 +320,8 @@ export class WeatherBar extends LitElement {
     }
     .bar-block-right {
       grid-area: right;
+      border: 1px solid var(--divider-color, lightgray);
+      border-width: 0 0 0 1px;
     }
     .bar-block-bottom {
       text-align: center;


### PR DESCRIPTION
In the changes for #476 I missed the fact that, previously, the ticks for each segment were 2px wide (border-width was set to 1px both left and right of each bar-block). With the current implementation, the ticks are barely visible on small displays or when the card is scaled down. Sorry about that.

This PR restores the original 2px width.