### PR TITLE
Feature: Add option to show current weather as the first segment

### DIFF
--- a/src/editor.ts
+++ b/src/editor.ts
@@ -58,6 +58,10 @@ export class HourlyWeatherCardEditor extends ScopedRegistryHost(LitElement) impl
     return this._config?.icons ?? false;
   }
 
+  get _show_current(): boolean {
+    return this._config?.show_current ?? false;
+  }
+
   get _show_wind(): WindType {
     return this._config?.show_wind ?? 'false';
   }
@@ -177,6 +181,13 @@ export class HourlyWeatherCardEditor extends ScopedRegistryHost(LitElement) impl
         <mwc-switch
           .checked=${this._show_precipitation_probability === true}
           .configValue=${'show_precipitation_probability'}
+          @change=${this._valueChanged}
+        ></mwc-switch>
+      </mwc-formfield>
+      <mwc-formfield .label=${localize('editor.show_current_weather')}>
+        <mwc-switch
+          .checked=${this._show_current === true}
+          .configValue=${'show_current'}
           @change=${this._valueChanged}
         ></mwc-switch>
       </mwc-formfield>

--- a/src/hourly-weather.ts
+++ b/src/hourly-weather.ts
@@ -233,7 +233,19 @@ export class HourlyWeatherCard extends LitElement {
 
     const entityId: string = config.entity;
     const state = this.hass.states[entityId];
-    const { forecast } = state.attributes as { forecast: ForecastSegment[] };
+    const forecast_only = state.attributes.forecast as ForecastSegment[];
+    const current: ForecastSegment = {
+      clouds: state.attributes.clouds, // 100
+      condition: state.state as string, // "cloudy"
+      datetime: state.last_updated, // "2022-06-03T22:00:00+00:00"
+      precipitation: state.attributes.precipitation, // 0
+      precipitation_probability: state.attributes.precipitation_probability, // 85
+      pressure: state.attributes.pressure, // 1007
+      temperature: state.attributes.temperature, // 61
+      wind_bearing: state.attributes.wind_bearing, // 153 | 'SSW'
+      wind_speed: state.attributes.wind_speed, // 3.06
+    };
+    const forecast = config.show_current === true ? [current, ...forecast_only] : forecast_only;
     const windSpeedUnit = state.attributes.wind_speed_unit ?? '';
     const precipitationUnit = state.attributes.precipitation_unit ?? '';
     const numSegments = parseInt(config.num_segments ?? config.num_hours ?? '12', 10);

--- a/src/localize/languages/en.json
+++ b/src/localize/languages/en.json
@@ -23,7 +23,8 @@
     "barb": "As wind barb",
     "barb_and_speed": "As wind barb and speed",
     "barb_and_direction": "As wind barb and direction",
-    "barb_speed_and_direction": "As wind barb, speed, and direction"
+    "barb_speed_and_direction": "As wind barb, speed, and direction",
+    "show_current_weather": "Show current weather"
   },
   "errors": {
     "missing_entity": "entity is missing in configuration",

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,6 +20,7 @@ export interface HourlyWeatherCardConfig extends LovelaceCardConfig {
   icons?: boolean;
   offset?: string; // number
   colors?: ColorConfig;
+  show_current?: boolean;
   hide_bar?: boolean;
   hide_hours?: boolean;
   hide_temperatures?: boolean;


### PR DESCRIPTION
This PR adds a config option to add the current weather as the first segment.:

![image](https://github.com/decompil3d/lovelace-hourly-weather/assets/7600867/c8015143-a17f-43f0-a859-08f269d912df)

![image](https://github.com/decompil3d/lovelace-hourly-weather/assets/7600867/e150e74a-78f8-45b7-b033-be12e25b4b38)


In its current state, the PR is meant as a request for comments. The following should completed before merging:

- Tests (I might be able to do that myself)
- Translations (not sure how to do that, other than by using online translation services)

I'd appreciate some input about this change. Thanks!