### PR TITLE
Feature: Allow negative offsets and show empty segments when no data is available

### DIFF
--- a/src/conditions.ts
+++ b/src/conditions.ts
@@ -13,7 +13,8 @@ export const LABELS = {
   'sunny': 'conditions.sunny',
   'windy': 'conditions.windy',
   'windy-variant': 'conditions.windy',
-  'exceptional': 'conditions.clear'
+  'exceptional': 'conditions.clear',
+  'empty': 'conditions.noData'
 };
 export const ICONS = {
   'clear-night': 'weather-night',

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -124,9 +124,6 @@ export class HourlyWeatherCardEditor extends ScopedRegistryHost(LitElement) impl
         .configValue=${'offset'}
         @input=${this._valueChanged}
         .type=${'number'}
-        .min=${0}
-        .autoValidate=${true}
-        validationMessage=${localize('errors.must_be_positive_int')}
       ></mwc-textfield>
       <mwc-textfield
       label=${localize('editor.label_spacing')}

--- a/src/localize/languages/en.json
+++ b/src/localize/languages/en.json
@@ -49,7 +49,8 @@
     "snow": "Snow",
     "mixedPrecip": "Mixed precip",
     "sunny": "Sunny",
-    "windy": "Windy"
+    "windy": "Windy",
+    "noData": "No data"
   },
   "direction": {
     "n": "N",

--- a/src/types.ts
+++ b/src/types.ts
@@ -58,6 +58,7 @@ export interface ColorConfig {
   'windy'?: ColorDefinition;
   'windy-variant'?: ColorDefinition;
   'exceptional'?: ColorDefinition;
+  'empty'?: ColorDefinition;
 }
 
 export interface ForecastSegment {

--- a/src/weather-bar.ts
+++ b/src/weather-bar.ts
@@ -51,6 +51,12 @@ export class WeatherBar extends LitElement {
   @property({ type: Number })
   label_spacing = 2;
 
+  @property({ type: Number })
+  num_empty_segments_leading = 0;
+
+  @property({ type: Number })
+  num_empty_segments_trailing = 0;
+
   @property({ type: Object })
   labels = LABELS;
 
@@ -58,8 +64,16 @@ export class WeatherBar extends LitElement {
 
   render() {
     const conditionBars: TemplateResult[] = [];
+    const emptyLabel = this.labels['empty'];
     let gridStart = 1;
     if (!this.hide_bar) {
+      if (this.num_empty_segments_leading > 0) {
+        const barStylesEmpty: Readonly<StyleInfo> = { gridColumnStart: String(gridStart), gridColumnEnd: String(gridStart += this.num_empty_segments_leading * 2) };
+        conditionBars.push(html`
+          <div class="empty" style=${styleMap(barStylesEmpty)} data-tippy-content=${emptyLabel}></div>
+        `);
+      }
+
       for (const cond of this.conditions) {
         const label = this.labels[cond[0]];
         let icon = ICONS[cond[0]];
@@ -74,11 +88,35 @@ export class WeatherBar extends LitElement {
           </div>
         `);
       }
+
+      if (this.num_empty_segments_trailing > 0) {
+        const barStylesEmpty: Readonly<StyleInfo> = { gridColumnStart: String(gridStart), gridColumnEnd: String(gridStart += this.num_empty_segments_trailing * 2) };
+        conditionBars.push(html`
+          <div class="empty" style=${styleMap(barStylesEmpty)} data-tippy-content=${emptyLabel}></div>
+        `);
+      }
     }
 
     const windCfg = this.show_wind ?? '';
     const barBlocks: TemplateResult[] = [];
     let lastDate: string | null = null;
+
+    for (let i = 0; i < this.num_empty_segments_leading; i += 1) {
+      barBlocks.push(html`
+        <div class="bar-block">
+          <div class="bar-block-left bar-block-empty"></div>
+          <div class="bar-block-right bar-block-empty"></div>
+          <div class="bar-block-bottom bar-block-empty">
+            <div class="date"></div>
+            <div class="hour"></div>
+            <div class="temperature"></div>
+            <div class="wind"></div>
+            <div class="precipitation"></div>
+          </div>
+        </div>
+      `);
+    }
+
     for (let i = 0; i < this.temperatures.length; i += 1) {
       const skipLabel = i % (this.label_spacing) !== 0;
       const hideHours = this.hide_hours || skipLabel;
@@ -131,6 +169,22 @@ export class WeatherBar extends LitElement {
             <div class="temperature">${hideTemperature ? null : html`${temperature}&deg;`}</div>
             <div class="wind">${wind}</div>
             <div class="precipitation">${precipitation}</div>
+          </div>
+        </div>
+      `);
+    }
+
+    for (let i = 0; i < this.num_empty_segments_trailing; i += 1) {
+      barBlocks.push(html`
+        <div class="bar-block">
+          <div class="bar-block-left bar-block-empty"></div>
+          <div class="bar-block-right bar-block-empty"></div>
+          <div class="bar-block-bottom bar-block-empty">
+            <div class="date"></div>
+            <div class="hour"></div>
+            <div class="temperature"></div>
+            <div class="wind"></div>
+            <div class="precipitation"></div>
           </div>
         </div>
       `);
@@ -203,6 +257,8 @@ export class WeatherBar extends LitElement {
       --color-windy: var(--color-sunny);
       --color-windy-variant: var(--color-sunny);
       --color-exceptional: #ff9d00;
+      --color-empty: #aaaaaa;
+      --color-empty-foreground: #dddddd;
     }
     .bar {
       height: 30px;
@@ -299,6 +355,11 @@ export class WeatherBar extends LitElement {
       background-color: var(--color-exceptional);
       color: var(--color-exceptional-foreground, var(--primary-text-color));
     }
+    .empty {
+      background-color: var(--color-empty);
+      background-image: repeating-linear-gradient(135deg, var(--color-empty) 0px, var(--color-empty) 2px, var(--color-empty-foreground, var(--color-empty)) 4px, var(--color-empty-foreground, var(--color-empty)) 6px, var(--color-empty) 8px);
+      color: var(--color-empty-foreground, var(--primary-text-color));
+    }
     .axes {
       display: grid;
       grid-auto-flow: column;
@@ -325,6 +386,9 @@ export class WeatherBar extends LitElement {
       text-align: center;
       grid-area: bottom;
       padding-top: 5px;
+    }
+    .bar-block-empty {
+      border-width: 0px;
     }
     .date, .hour {
       color: var(--secondary-text-color, gray);


### PR DESCRIPTION
This PR enables setting _offset_ to both negative values and values larger than the amount of available data. This allows creating weather bars with fixed num_segments that don't change their layouts as time passes. It can be useful to show daily weather bars:

![image](https://github.com/decompil3d/lovelace-hourly-weather/assets/7600867/acb768c9-0c84-4cbb-90a1-4de7ef009aba)

In its current state, the PR is meant as a request for comments. The following should completed before merging:

- Tests (I might be able to do that myself)
- Translations (not sure how to do that, other than by using online translation services)

I'd appreciate some input about this change. Thanks!