### PR TITLE
Support for new forecast subscriptions mechanism in HA 2023.9.0+

### DIFF
--- a/.github/workflows/validate-loc.yml
+++ b/.github/workflows/validate-loc.yml
@@ -29,10 +29,11 @@ jobs:
             });
             const langCodes = newLanguages.map(l => l.filename.replace('src/localize/languages/', '').replace('.json', ''));
             console.log('New languages added:', langCodes.join(', '));
-            return langCodes;
+            return langCodes.length > 0 ? langCodes : null;
   validate-added-languages:
     needs: find-new-languages
     runs-on: ubuntu-latest
+    if: ${{ fromJSON(needs.find-new-languages.outputs.languages) != null }}
     strategy:
       fail-fast: true
       matrix:

--- a/README.md
+++ b/README.md
@@ -38,48 +38,52 @@ If you prefer YAML, here is a sample config:
 
 ```yaml
 type: custom:hourly-weather
-entity: weather.my_hourly_weather_entity
+entity: weather.my_weather_entity
 num_segments: 18 # optional, defaults to 12
 name: Next 18 hours # optional, defaults to "Hourly Weather"
 ```
 
 ### Choosing the right entity
 
-This card is focused on displaying hourly weather data. If you try selecting a weather entity that provides daily
-forecasts, it will show a warning. I've tested with the OpenWeatherMap integration using the `onecall_hourly` mode and
-that works very well.
+This card is focused on displaying hourly weather data. It will work with coarser- or finer-grained data, though. I've
+tested with the OpenWeatherMap integration using the `onecall_hourly` mode and that works very well.
+
+As of Home Assistant 2023.9.0, most weather integrations provide data in multiple time increments. If your weather
+entity provides hourly data, the card will use that by default. Otherwise, the card will attempt to use the
+finest-grained increments available, unless you have configured otherwise.
 
 > ℹ️ NOTE: If your selected weather entity provides forecasts in increments of greater than one hour at a time, each
 > segment of the bar will be for one segment, not one hour.
 
-If you already use OpenWeatherMap for daily data, you can add a second integration of the same
-component for hourly -- just adjust the latitude or longitude a tiny bit (i.e. change the last decimal by 1).
-Otherwise, the integration may complain of a duplicate unique ID.
+Prior to Home Assistant version 2023.9.0, if you already use OpenWeatherMap for daily data, you can add a second
+integration of the same component for hourly -- just adjust the latitude or longitude a tiny bit (i.e. change the last
+decimal by 1). Otherwise, the integration may complain of a duplicate unique ID.
 
 ## Options
 
-| Name                             | Type             | Requirement  | Description                                                    | Default             |
-|----------------------------------|------------------|--------------|----------------------------------------------------------------|---------------------|
-| `type`                           | string           | **Required** | `custom:hourly-weather`                                        |                     |
-| `entity`                         | string           | **Required** | Home Assistant weather entity ID.                              |                     |
-| `name`                           | string           | **Optional** | Card name (set to `null` to hide)                              | `Hourly Weather`    |
-| `icons`                          | bool             | **Optional** | Whether to show icons instead of text labels                   | `false`             |
-| `num_segments`                   | number           | **Optional** | Number of forecast segments to show (integer >= 1)             | `12`                |
-| ~~`num_hours`~~                  | number           | **Optional** | _Deprecated:_ Use `num_segments` instead                       | `12`                |
-| `offset`                         | number           | **Optional** | Number of forecast segments to offset from start               | `0`                 |
-| `label_spacing`                  | number           | **Optional** | Space between time/temperature labels (integer >= 1)           | `2`                 |
-| `colors`                         | [object][color]  | **Optional** | Set colors for all or some conditions                          |                     |
-| `hide_hours`                     | bool             | **Optional** | Whether to hide hour labels under the bar                      | `false`             |
-| `hide_temperatures`              | bool             | **Optional** | Whether to hide temperatures under the bar                     | `false`             |
-| `hide_bar`                       | bool             | **Optional** | Whether to hide the bar itself                                 | `false`             |
-| `show_wind`                      | [Wind][wind]     | **Optional** | Whether to show wind speed and/or direction under the bar      | `'false'`           |
-| `show_precipitation_amounts`     | bool             | **Optional** | Whether to show precipitation (rain) amount under the bar      | `false`             |
-| `show_precipitation_probability` | bool             | **Optional** | Whether to show precipitation (rain) probability under the bar | `false`             |
-| `show_date`                      | [string][dates]  | **Optional** | Whether to show date under the bar                             | `'false'`           |
-| `tap_action`                     | [object][action] | **Optional** | Action to take on tap                                          | `action: more-info` |
-| `hold_action`                    | [object][action] | **Optional** | Action to take on hold                                         | `none`              |
-| `double_tap_action`              | [object][action] | **Optional** | Action to take on double tap                                   | `none`              |
-| `language`                       | string           | **Optional** | Language to use for card (overrides HA & user settings)        |                     |
+| Name                             | Type             | Requirement  | Description                                                                                                                                                     | Default             |
+|----------------------------------|------------------|--------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------|
+| `type`                           | string           | **Required** | `custom:hourly-weather`                                                                                                                                         |                     |
+| `entity`                         | string           | **Required** | Home Assistant weather entity ID.                                                                                                                               |                     |
+| `forecast_type`                  | string           | **Optional** | The type of forecast data to use. One of `hourly`, `daily`, or `twice-daily`. If not specified, the card will attempt to use the finest-grained data available. |                     |
+| `name`                           | string           | **Optional** | Card name (set to `null` to hide)                                                                                                                               | `Hourly Weather`    |
+| `icons`                          | bool             | **Optional** | Whether to show icons instead of text labels                                                                                                                    | `false`             |
+| `num_segments`                   | number           | **Optional** | Number of forecast segments to show (integer >= 1)                                                                                                              | `12`                |
+| ~~`num_hours`~~                  | number           | **Optional** | _Deprecated:_ Use `num_segments` instead                                                                                                                        | `12`                |
+| `offset`                         | number           | **Optional** | Number of forecast segments to offset from start                                                                                                                | `0`                 |
+| `label_spacing`                  | number           | **Optional** | Space between time/temperature labels (integer >= 1)                                                                                                            | `2`                 |
+| `colors`                         | [object][color]  | **Optional** | Set colors for all or some conditions                                                                                                                           |                     |
+| `hide_hours`                     | bool             | **Optional** | Whether to hide hour labels under the bar                                                                                                                       | `false`             |
+| `hide_temperatures`              | bool             | **Optional** | Whether to hide temperatures under the bar                                                                                                                      | `false`             |
+| `hide_bar`                       | bool             | **Optional** | Whether to hide the bar itself                                                                                                                                  | `false`             |
+| `show_wind`                      | [Wind][wind]     | **Optional** | Whether to show wind speed and/or direction under the bar                                                                                                       | `'false'`           |
+| `show_precipitation_amounts`     | bool             | **Optional** | Whether to show precipitation (rain) amount under the bar                                                                                                       | `false`             |
+| `show_precipitation_probability` | bool             | **Optional** | Whether to show precipitation (rain) probability under the bar                                                                                                  | `false`             |
+| `show_date`                      | [string][dates]  | **Optional** | Whether to show date under the bar                                                                                                                              | `'false'`           |
+| `tap_action`                     | [object][action] | **Optional** | Action to take on tap                                                                                                                                           | `action: more-info` |
+| `hold_action`                    | [object][action] | **Optional** | Action to take on hold                                                                                                                                          | `none`              |
+| `double_tap_action`              | [object][action] | **Optional** | Action to take on double tap                                                                                                                                    | `none`              |
+| `language`                       | string           | **Optional** | Language to use for card (overrides HA & user settings)                                                                                                         |                     |
 
 > Note that some of the more advanced options are not available in the card editor UI and must be configured via YAML.
 

--- a/cypress/e2e/card.cy.ts
+++ b/cypress/e2e/card.cy.ts
@@ -18,7 +18,6 @@ describe('Card', () => {
   it('renders a graceful message when forecast is missing', () => {
     cy.addEntity({
       'weather.no_forecast': {
-        // @ts-expect-error testing behavior with no forecast attribute
         attributes: {}
       }
     });

--- a/cypress/e2e/config.cy.ts
+++ b/cypress/e2e/config.cy.ts
@@ -41,6 +41,33 @@ describe('Config', () => {
       .find('p')
       .should('have.text', 'Too many forecast segments requested in num_segments. Must be <= number of segments in forecast entity.');
   });
+  it('handles boolean values for show_wind', () => {
+    cy.configure({
+      show_wind: true
+    });
+    cy.get('weather-bar')
+      .shadow()
+      .find('div.axes > div.bar-block div.wind')
+      .should('have.length', 12)
+      .each((el, i) => {
+        if (i % 2 === 0) {
+          cy.wrap(el).should('not.be.empty');
+        }
+      });
+
+    cy.configure({
+      show_wind: false
+    });
+    cy.get('weather-bar')
+      .shadow()
+      .find('div.axes > div.bar-block div.wind')
+      .should('have.length', 12)
+      .each((el, i) => {
+        if (i % 2 === 0) {
+          cy.wrap(el).should('be.empty');
+        }
+      });
+  });
   it('errors for wind barbs when entity uses cardinal directions for wind bearing', () => {
     cy.addEntity({
       'weather.wind_bearing_string': {

--- a/cypress/e2e/config.cy.ts
+++ b/cypress/e2e/config.cy.ts
@@ -215,56 +215,6 @@ describe('Config', () => {
       .find('p')
       .should('have.text', 'Wind barbs are not supported when weather entity uses cardinal directions for wind bearing.');
   });
-  it('warns for daily forecasts', () => {
-    cy.addEntity({
-      'weather.daily': {
-        attributes: {
-          forecast: [{
-            clouds: 100,
-            condition: 'cloudy',
-            datetime: '2022-06-03T22:00:00+00:00',
-            precipitation: 0,
-            precipitation_probability: 85,
-            pressure: 1007,
-            temperature: 61,
-            wind_bearing: 153,
-            wind_speed: 3.06
-          }, {
-            clouds: 100,
-            condition: 'cloudy',
-            datetime: '2022-06-04T22:00:00+00:00',
-            precipitation: 0,
-            precipitation_probability: 85,
-            pressure: 1007,
-            temperature: 61,
-            wind_bearing: 153,
-            wind_speed: 3.06
-          }, {
-            clouds: 100,
-            condition: 'cloudy',
-            datetime: '2022-06-05T22:00:00+00:00',
-            precipitation: 0,
-            precipitation_probability: 85,
-            pressure: 1007,
-            temperature: 61,
-            wind_bearing: 153,
-            wind_speed: 3.06
-          }]
-        }
-      }
-    });
-    cy.configure({
-      entity: 'weather.daily',
-      num_segments: '3'
-    });
-    cy.get('hui-warning')
-      .shadow()
-      .slotAssignedNodes()
-      .should('have.length', 1)
-      .its(0)
-      .its('textContent')
-      .should('eq', 'The selected weather entity seems to provide daily forecasts. Consider switching to an hourly entity.');
-  });
   it('warns for invalid colors', () => {
     cy.configure({
       colors: {
@@ -389,4 +339,427 @@ describe('Config', () => {
         });
       });
     });
+  describe('Forecast events from subscription', () => {
+    beforeEach(() => {
+      cy.enableForecastSubscriptions();
+    });
+
+    it('uses forecast from subscription when available', () => {
+      cy.addEntity({
+        'weather.fromSub': {
+          attributes: {
+            forecast: [
+              {
+                "datetime": "2022-07-21T17:00:00+00:00",
+                "precipitation": 0.35,
+                "precipitation_probability": 75,
+                "pressure": 1007,
+                "wind_speed": 4.67,
+                "wind_bearing": 255,
+                "condition": "sunny",
+                "clouds": 60,
+                "temperature": 84
+              },
+              {
+                "datetime": "2022-07-21T18:00:00+00:00",
+                "precipitation": 0.35,
+                "precipitation_probability": 75,
+                "pressure": 1007,
+                "wind_speed": 6.07,
+                "wind_bearing": 253,
+                "condition": "sunny",
+                "clouds": 75,
+                "temperature": 85
+              },
+              {
+                "datetime": "2022-07-21T19:00:00+00:00",
+                "precipitation": 1.3,
+                "precipitation_probability": 100,
+                "pressure": 1007,
+                "wind_speed": 6.16,
+                "wind_bearing": 258,
+                "condition": "sunny",
+                "clouds": 60,
+                "temperature": 85
+              },
+              {
+                "datetime": "2022-07-21T20:00:00+00:00",
+                "precipitation": 1.3,
+                "precipitation_probability": 100,
+                "pressure": 1007,
+                "wind_speed": 5.9,
+                "wind_bearing": 278,
+                "condition": "sunny",
+                "clouds": 49,
+                "temperature": 84
+              },
+              {
+                "datetime": "2022-07-21T21:00:00+00:00",
+                "precipitation": 0,
+                "precipitation_probability": 15,
+                "pressure": 1007,
+                "wind_speed": 5.78,
+                "wind_bearing": 297,
+                "condition": "sunny",
+                "clouds": 34,
+                "temperature": 84
+              },
+              {
+                "datetime": "2022-07-21T22:00:00+00:00",
+                "precipitation": 0,
+                "precipitation_probability": 15,
+                "pressure": 1008,
+                "wind_speed": 5.06,
+                "wind_bearing": 293,
+                "condition": "sunny",
+                "clouds": 19,
+                "temperature": 83
+              }
+            ]
+          }
+        }
+      });
+      cy.addForecast('weather.fromSub', [
+        {
+          "datetime": "2022-07-21T17:00:00+00:00",
+          "precipitation": 0.35,
+          "precipitation_probability": 75,
+          "pressure": 1007,
+          "wind_speed": 4.67,
+          "wind_bearing": 255,
+          "condition": "snowy",
+          "clouds": 60,
+          "temperature": 84
+        },
+        {
+          "datetime": "2022-07-21T18:00:00+00:00",
+          "precipitation": 0.35,
+          "precipitation_probability": 75,
+          "pressure": 1007,
+          "wind_speed": 6.07,
+          "wind_bearing": 253,
+          "condition": "snowy",
+          "clouds": 75,
+          "temperature": 85
+        },
+        {
+          "datetime": "2022-07-21T19:00:00+00:00",
+          "precipitation": 1.3,
+          "precipitation_probability": 100,
+          "pressure": 1007,
+          "wind_speed": 6.16,
+          "wind_bearing": 258,
+          "condition": "snowy",
+          "clouds": 60,
+          "temperature": 85
+        },
+        {
+          "datetime": "2022-07-21T20:00:00+00:00",
+          "precipitation": 1.3,
+          "precipitation_probability": 100,
+          "pressure": 1007,
+          "wind_speed": 5.9,
+          "wind_bearing": 278,
+          "condition": "snowy",
+          "clouds": 49,
+          "temperature": 84
+        },
+        {
+          "datetime": "2022-07-21T21:00:00+00:00",
+          "precipitation": 0,
+          "precipitation_probability": 15,
+          "pressure": 1007,
+          "wind_speed": 5.78,
+          "wind_bearing": 297,
+          "condition": "snowy",
+          "clouds": 34,
+          "temperature": 84
+        },
+        {
+          "datetime": "2022-07-21T22:00:00+00:00",
+          "precipitation": 0,
+          "precipitation_probability": 15,
+          "pressure": 1008,
+          "wind_speed": 5.06,
+          "wind_bearing": 293,
+          "condition": "snowy",
+          "clouds": 19,
+          "temperature": 83
+        }
+      ]);
+
+      cy.configure({
+        entity: 'weather.fromSub',
+        num_segments: '6',
+      });
+
+      // Legacy attributes will have other conditions, but the subscription-based forecast will be snowy
+      cy.get('weather-bar')
+      .shadow()
+      .find('div.bar > div')
+      .each((el) => {
+        cy.wrap(el).invoke('attr', 'data-tippy-content')
+          .should('exist')
+          .and('eq', 'Snow')
+      });
+    });
+
+    it('uses forecast from subscription even when forecast attribute is not on entity', () => {
+      cy.addEntity({
+        'weather.fromSub': {
+          attributes: {}
+        }
+      });
+      cy.addForecast('weather.fromSub', [
+        {
+          "datetime": "2022-07-21T17:00:00+00:00",
+          "precipitation": 0.35,
+          "precipitation_probability": 75,
+          "pressure": 1007,
+          "wind_speed": 4.67,
+          "wind_bearing": 255,
+          "condition": "snowy",
+          "clouds": 60,
+          "temperature": 84
+        },
+        {
+          "datetime": "2022-07-21T18:00:00+00:00",
+          "precipitation": 0.35,
+          "precipitation_probability": 75,
+          "pressure": 1007,
+          "wind_speed": 6.07,
+          "wind_bearing": 253,
+          "condition": "snowy",
+          "clouds": 75,
+          "temperature": 85
+        },
+        {
+          "datetime": "2022-07-21T19:00:00+00:00",
+          "precipitation": 1.3,
+          "precipitation_probability": 100,
+          "pressure": 1007,
+          "wind_speed": 6.16,
+          "wind_bearing": 258,
+          "condition": "snowy",
+          "clouds": 60,
+          "temperature": 85
+        },
+        {
+          "datetime": "2022-07-21T20:00:00+00:00",
+          "precipitation": 1.3,
+          "precipitation_probability": 100,
+          "pressure": 1007,
+          "wind_speed": 5.9,
+          "wind_bearing": 278,
+          "condition": "snowy",
+          "clouds": 49,
+          "temperature": 84
+        },
+        {
+          "datetime": "2022-07-21T21:00:00+00:00",
+          "precipitation": 0,
+          "precipitation_probability": 15,
+          "pressure": 1007,
+          "wind_speed": 5.78,
+          "wind_bearing": 297,
+          "condition": "snowy",
+          "clouds": 34,
+          "temperature": 84
+        },
+        {
+          "datetime": "2022-07-21T22:00:00+00:00",
+          "precipitation": 0,
+          "precipitation_probability": 15,
+          "pressure": 1008,
+          "wind_speed": 5.06,
+          "wind_bearing": 293,
+          "condition": "snowy",
+          "clouds": 19,
+          "temperature": 83
+        }
+      ]);
+
+      cy.configure({
+        entity: 'weather.fromSub',
+        num_segments: '6',
+      });
+
+      cy.get('weather-bar')
+      .shadow()
+      .find('div.bar > div')
+      .each((el) => {
+        cy.wrap(el).invoke('attr', 'data-tippy-content')
+          .should('exist')
+          .and('eq', 'Snow')
+      });
+    });
+
+    it('handles forecast updates via subscription', () => {
+      cy.addEntity({
+        'weather.fromSub': {
+          attributes: {}
+        }
+      });
+      cy.addForecast('weather.fromSub', [
+        {
+          "datetime": "2022-07-21T17:00:00+00:00",
+          "precipitation": 0.35,
+          "precipitation_probability": 75,
+          "pressure": 1007,
+          "wind_speed": 4.67,
+          "wind_bearing": 255,
+          "condition": "snowy",
+          "clouds": 60,
+          "temperature": 84
+        },
+        {
+          "datetime": "2022-07-21T18:00:00+00:00",
+          "precipitation": 0.35,
+          "precipitation_probability": 75,
+          "pressure": 1007,
+          "wind_speed": 6.07,
+          "wind_bearing": 253,
+          "condition": "snowy",
+          "clouds": 75,
+          "temperature": 85
+        },
+        {
+          "datetime": "2022-07-21T19:00:00+00:00",
+          "precipitation": 1.3,
+          "precipitation_probability": 100,
+          "pressure": 1007,
+          "wind_speed": 6.16,
+          "wind_bearing": 258,
+          "condition": "snowy",
+          "clouds": 60,
+          "temperature": 85
+        },
+        {
+          "datetime": "2022-07-21T20:00:00+00:00",
+          "precipitation": 1.3,
+          "precipitation_probability": 100,
+          "pressure": 1007,
+          "wind_speed": 5.9,
+          "wind_bearing": 278,
+          "condition": "snowy",
+          "clouds": 49,
+          "temperature": 84
+        },
+        {
+          "datetime": "2022-07-21T21:00:00+00:00",
+          "precipitation": 0,
+          "precipitation_probability": 15,
+          "pressure": 1007,
+          "wind_speed": 5.78,
+          "wind_bearing": 297,
+          "condition": "snowy",
+          "clouds": 34,
+          "temperature": 84
+        },
+        {
+          "datetime": "2022-07-21T22:00:00+00:00",
+          "precipitation": 0,
+          "precipitation_probability": 15,
+          "pressure": 1008,
+          "wind_speed": 5.06,
+          "wind_bearing": 293,
+          "condition": "snowy",
+          "clouds": 19,
+          "temperature": 83
+        }
+      ]);
+
+      cy.configure({
+        entity: 'weather.fromSub',
+        num_segments: '6',
+      });
+
+      cy.get('weather-bar')
+      .shadow()
+      .find('div.bar > div')
+      .each((el) => {
+        cy.wrap(el).invoke('attr', 'data-tippy-content')
+          .should('exist')
+          .and('eq', 'Snow')
+      });
+
+      cy.updateLastForecastSubscription([
+        {
+          "datetime": "2022-07-21T17:00:00+00:00",
+          "precipitation": 0.35,
+          "precipitation_probability": 75,
+          "pressure": 1007,
+          "wind_speed": 4.67,
+          "wind_bearing": 255,
+          "condition": "rainy",
+          "clouds": 60,
+          "temperature": 84
+        },
+        {
+          "datetime": "2022-07-21T18:00:00+00:00",
+          "precipitation": 0.35,
+          "precipitation_probability": 75,
+          "pressure": 1007,
+          "wind_speed": 6.07,
+          "wind_bearing": 253,
+          "condition": "rainy",
+          "clouds": 75,
+          "temperature": 85
+        },
+        {
+          "datetime": "2022-07-21T19:00:00+00:00",
+          "precipitation": 1.3,
+          "precipitation_probability": 100,
+          "pressure": 1007,
+          "wind_speed": 6.16,
+          "wind_bearing": 258,
+          "condition": "rainy",
+          "clouds": 60,
+          "temperature": 85
+        },
+        {
+          "datetime": "2022-07-21T20:00:00+00:00",
+          "precipitation": 1.3,
+          "precipitation_probability": 100,
+          "pressure": 1007,
+          "wind_speed": 5.9,
+          "wind_bearing": 278,
+          "condition": "rainy",
+          "clouds": 49,
+          "temperature": 84
+        },
+        {
+          "datetime": "2022-07-21T21:00:00+00:00",
+          "precipitation": 0,
+          "precipitation_probability": 15,
+          "pressure": 1007,
+          "wind_speed": 5.78,
+          "wind_bearing": 297,
+          "condition": "rainy",
+          "clouds": 34,
+          "temperature": 84
+        },
+        {
+          "datetime": "2022-07-21T22:00:00+00:00",
+          "precipitation": 0,
+          "precipitation_probability": 15,
+          "pressure": 1008,
+          "wind_speed": 5.06,
+          "wind_bearing": 293,
+          "condition": "rainy",
+          "clouds": 19,
+          "temperature": 83
+        }
+      ]);
+
+      cy.get('weather-bar')
+      .shadow()
+      .find('div.bar > div')
+      .each((el) => {
+        cy.wrap(el).invoke('attr', 'data-tippy-content')
+          .should('exist')
+          .and('eq', 'Rain')
+      });
+    });
+  });
 });

--- a/cypress/fixtures/harness.html
+++ b/cypress/fixtures/harness.html
@@ -25,10 +25,29 @@
     const h = document.createElement('hourly-weather');
     const now = new Date();
     now.setMinutes(0);
+    /**
+     * @typedef {{ type: 'render_remplate', template: string}} TemplateSubscribeMessageOpts
+     * @typedef {{ type: 'weather/subscribe_forecast', forecast_type: string, entity_id: string}} ForecastSubscribeMessageOpts
+     * @typedef {TemplateSubscribeMessageOpts | ForecastSubscribeMessageOpts} SubscribeMessageOpts
+     */
     h.hass = {
       connection: {
-        subscribeMessage: (/** @type {(msg: string) => void} */ cb, /** @type {{template: string}} */ { template }) => {
-          cb({ result: 'TEMPLATE:' + template.replace(/\{\{\s*/, '').replace(/\s*\}\}/, '') });
+        subscribeMessage: (/** @type {(msg: string) => void} */ cb, /** @type {SubscribeMessageOpts} */ { type, template, forecast_type, entity_id }) => {
+          if (type === 'render_template') {
+            cb({ result: 'TEMPLATE:' + template.replace(/\{\{\s*/, '').replace(/\s*\}\}/, '') });
+            return;
+          }
+          if (type === 'weather/subscribe_forecast') {
+            window.lastForecastSubCallback = cb;
+            cb({
+              forecast: window.HWForecasts[entity_id] ?? h.hass.states[entity_id].attributes.forecast
+            });
+            return {
+              then(/** @type {(unsub: () => void) => void} **/ f) {
+                f(function noop_unsub() {});
+              }
+            }
+          }
         },
       },
       states: {
@@ -581,7 +600,17 @@
           ...h.hass.states,
           ...entity
         }
-      }
+      };
+      window.HWForecasts = {};
+      window.addHWForecast = (entityId, forecast) => window.HWForecasts[entityId] = forecast;
+      window.enableHWForecastSubscriptions = () => h.hass = {
+        ...h.hass,
+        services: {
+          weather: {
+            get_forecast: () => {}
+          }
+        }
+      };
       window.setHWLocale = locale => h.hass = {
         ...h.hass,
         locale: {
@@ -594,6 +623,11 @@
         entity: 'weather.mock',
         num_segments: 12
       });
+      window.updateLastForecastSubscription = forecast => {
+        window.lastForecastSubCallback({
+          forecast
+        });
+      };
       window.appReady = true;
     });
   </script>

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -50,12 +50,24 @@ Cypress.Commands.add('configure', (config: Partial<HourlyWeatherCardConfig>, noD
 
 interface WeatherEntity {
   attributes: {
-    forecast: ForecastSegment[];
+    forecast?: ForecastSegment[];
   };
 }
 
 Cypress.Commands.add('addEntity', (entities: Record<string, WeatherEntity>) => {
   cy.window().invoke('addHWEntity', entities).wait(1);
+});
+
+Cypress.Commands.add('addForecast', (entityId: string, forecast: ForecastSegment[]) => {
+  cy.window().invoke('addHWForecast', entityId, forecast).wait(1);
+});
+
+Cypress.Commands.add('enableForecastSubscriptions', () => {
+  cy.window().invoke('enableHWForecastSubscriptions').wait(1);
+});
+
+Cypress.Commands.add('updateLastForecastSubscription', (forecast: ForecastSegment[]) => {
+  cy.window().invoke('updateLastForecastSubscription', forecast).wait(1);
 });
 
 interface HALocale {
@@ -84,6 +96,9 @@ declare global {
       visitHarness(windowStubFn?: (win: Cypress.AUTWindow) => void): Chainable<Window>;
       configure(config: Partial<HourlyWeatherCardConfig>, noDefaults?: boolean): Chainable<void>;
       addEntity(entities: Record<string, WeatherEntity>): Chainable<void>;
+      addForecast(entityId: string, forecast: ForecastSegment[]): Chainable<void>;
+      enableForecastSubscriptions(): Chainable<void>;
+      updateLastForecastSubscription(forecast: ForecastSegment[]): Chainable<void>;
       setLocale(locale: Partial<HALocale>): Chainable<void>;
       slotAssignedNodes(name?: string): Chainable<Node[]>;
     }

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -59,7 +59,11 @@ export class HourlyWeatherCardEditor extends ScopedRegistryHost(LitElement) impl
   }
 
   get _show_wind(): WindType {
-    return this._config?.show_wind ?? 'false';
+    const showWind = this._config?.show_wind;
+    if (typeof showWind === 'boolean') {
+      return showWind ? 'true' : 'false';
+    }
+    return showWind ?? 'false';
   }
 
   get _show_precipitation_amounts(): boolean {

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -78,6 +78,10 @@ export class HourlyWeatherCardEditor extends ScopedRegistryHost(LitElement) impl
     return this._config?.label_spacing ?? '2';
   }
 
+  get _show_date(): string {
+    return this._config?.show_date ?? 'false';
+  }
+
   protected render(): TemplateResult | void {
     if (!this.hass || !this._helpers) {
       return html``;
@@ -165,6 +169,20 @@ export class HourlyWeatherCardEditor extends ScopedRegistryHost(LitElement) impl
         <mwc-list-item value="barb-and-speed">${localize('editor.barb_and_speed')}</mwc-list-item>
         <mwc-list-item value="barb-and-direction">${localize('editor.barb_and_direction')}</mwc-list-item>
         <mwc-list-item value="barb-speed-and-direction">${localize('editor.barb_speed_and_direction')}</mwc-list-item>
+      </mwc-select>
+      <mwc-select
+        naturalMenuWidth
+        fixedMenuPosition
+        label=${localize('editor.show_date')}
+        .configValue=${'show_date'}
+        .value=${this._show_date}
+        @selected=${this._valueChanged}
+        @closed=${(ev) => ev.stopPropagation()}
+      >
+        <mwc-list-item></mwc-list-item>
+        <mwc-list-item value="false">${localize('editor.none')}</mwc-list-item>
+        <mwc-list-item value="all">${localize('editor.all')}</mwc-list-item>
+        <mwc-list-item value="boundary">${localize('editor.on_day_boundaries')}</mwc-list-item>
       </mwc-select>
       <mwc-formfield .label=${localize('editor.show_precipitation_amounts')}>
         <mwc-switch

--- a/src/hourly-weather.ts
+++ b/src/hourly-weather.ts
@@ -24,15 +24,15 @@ import type {
   ColorObject,
   ColorSettings,
   ConditionSpan,
+  ForecastEvent,
   ForecastSegment,
+  ForecastType,
   HourlyWeatherCardConfig,
   LocalizerLastSettings,
   RenderTemplateResult,
+  SegmentPrecipitation,
   SegmentTemperature,
   SegmentWind,
-  SegmentPrecipitation,
-  ForecastEvent,
-  ForecastType,
 } from './types';
 import { actionHandler } from './action-handler-directive';
 import { version } from '../package.json';
@@ -337,7 +337,7 @@ export class HourlyWeatherCard extends LitElement {
       return await this._showError(this.localize('errors.offset_must_be_positive_int', 'offset', 'label_spacing'));
     }
 
-    if (config.show_wind?.includes('barb') && typeof forecast?.[0].wind_bearing === 'string') {
+    if (config.show_wind?.includes?.('barb') && typeof forecast?.[0].wind_bearing === 'string') {
       return await this._showError(this.localize('errors.no_wind_barbs_with_string_bearing'));
     }
 

--- a/src/hourly-weather.ts
+++ b/src/hourly-weather.ts
@@ -337,7 +337,11 @@ export class HourlyWeatherCard extends LitElement {
       return await this._showError(this.localize('errors.offset_must_be_positive_int', 'offset', 'label_spacing'));
     }
 
-    if (config.show_wind?.includes?.('barb') && typeof forecast?.[0].wind_bearing === 'string') {
+    let showWind = config.show_wind;
+    if (typeof showWind === 'boolean') {
+      showWind = showWind ? 'true' : 'false';
+    }
+    if (showWind?.includes('barb') && typeof forecast?.[0].wind_bearing === 'string') {
       return await this._showError(this.localize('errors.no_wind_barbs_with_string_bearing'));
     }
 
@@ -392,7 +396,7 @@ export class HourlyWeatherCard extends LitElement {
             .hide_hours=${!!config.hide_hours}
             .hide_temperatures=${!!config.hide_temperatures}
             .hide_bar=${!!config.hide_bar}
-            .show_wind=${config.show_wind}
+            .show_wind=${showWind}
             .show_precipitation_amounts=${!!config.show_precipitation_amounts}
             .show_precipitation_probability=${!!config.show_precipitation_probability}
             .show_date=${config.show_date}

--- a/src/hourly-weather.ts
+++ b/src/hourly-weather.ts
@@ -31,6 +31,8 @@ import type {
   SegmentTemperature,
   SegmentWind,
   SegmentPrecipitation,
+  ForecastEvent,
+  ForecastType,
 } from './types';
 import { actionHandler } from './action-handler-directive';
 import { version } from '../package.json';
@@ -76,6 +78,9 @@ export class HourlyWeatherCard extends LitElement {
   @state() private config!: HourlyWeatherCardConfig;
 
   @state() private renderedConfig!: Promise<HourlyWeatherCardConfig>;
+
+  @state() private forecastEvent?: ForecastEvent;
+  @state() private subscribedToForecast?: Promise<() => void>;
 
   private configRenderPending = false;
 
@@ -125,6 +130,53 @@ export class HourlyWeatherCard extends LitElement {
       this.directionsLocalized = true;
     }
     return this._directions;
+  }
+
+  private unsubscribeForecastEvents() {
+    if (this.subscribedToForecast) {
+      this.subscribedToForecast.then((unsub) => unsub());
+      this.subscribedToForecast = undefined;
+    }
+  }
+
+  private async subscribeToForecastEvents() {
+    this.unsubscribeForecastEvents();
+    if (!this.isConnected || !this.hass || !this.config || !this.config.entity || !this.hassSupportsForecastEvents()) {
+      return;
+    }
+
+    const forecastType = this.getIdealForecastType();
+    this.subscribedToForecast = this.hass.connection.subscribeMessage<ForecastEvent>(
+      evt => this.forecastEvent = evt,
+      {
+        type: 'weather/subscribe_forecast',
+        forecast_type: forecastType,
+        entity_id: this.config.entity
+      });
+  }
+
+  private getIdealForecastType(): ForecastType {
+    if (this.config?.forecast_type) {
+      return this.config.forecast_type;
+    }
+    if (!this.config?.entity) {
+      return 'hourly';
+    }
+    const state = this.hass.states[this.config.entity];
+    if (!state) {
+      return 'hourly';
+    }
+    const supportedFeatures = state.attributes.supported_features;
+    if (!supportedFeatures) {
+      return 'hourly';
+    }
+    if (supportedFeatures & 0x2) {
+      return 'hourly';
+    }
+    if (supportedFeatures & 0x4) {
+      return 'twice_daily';
+    }
+    return 'daily';
   }
 
   // https://lit.dev/docs/components/properties/#accessors-custom
@@ -194,6 +246,18 @@ export class HourlyWeatherCard extends LitElement {
     });
   }
 
+  public connectedCallback(): void {
+    super.connectedCallback();
+    if (this.hasUpdated) {
+      this.subscribeToForecastEvents();
+    }
+  }
+
+  public disconnectedCallback(): void {
+    super.disconnectedCallback();
+    this.unsubscribeForecastEvents();
+  }
+
   // https://lit.dev/docs/components/lifecycle/#reactive-update-cycle-performing
   protected shouldUpdate(changedProps: PropertyValues): boolean {
     if (!this.config) {
@@ -211,11 +275,25 @@ export class HourlyWeatherCard extends LitElement {
     return hasConfigOrEntityChanged(this, changedProps, false);
   }
 
-  protected updated(): void {
+  protected updated(changedProps: PropertyValues): void {
+    super.updated(changedProps);
+
     if (this.hass?.connection && this.configRenderPending) {
       this.configRenderPending = false;
       this.triggerConfigRender();
     }
+    if (!this.subscribedToForecast ||
+        (changedProps.has('config') && this.config?.entity !== changedProps.get('config')?.entity)) {
+      this.subscribeToForecastEvents();
+    }
+  }
+
+  private getForecast(): ForecastSegment[] | undefined {
+    return this.forecastEvent?.forecast ?? this.hass?.states[this.config.entity]?.attributes.forecast;
+  }
+
+  private hassSupportsForecastEvents(): boolean {
+    return !!(this.hass?.services?.weather?.get_forecast);
   }
 
   // https://lit.dev/docs/components/rendering/
@@ -233,7 +311,7 @@ export class HourlyWeatherCard extends LitElement {
 
     const entityId: string = config.entity;
     const state = this.hass.states[entityId];
-    const { forecast } = state.attributes as { forecast: ForecastSegment[] };
+    const forecast = this.getForecast();
     const windSpeedUnit = state.attributes.wind_speed_unit ?? '';
     const precipitationUnit = state.attributes.precipitation_unit ?? '';
     const numSegments = parseInt(config.num_segments ?? config.num_hours ?? '12', 10);
@@ -259,7 +337,7 @@ export class HourlyWeatherCard extends LitElement {
       return await this._showError(this.localize('errors.offset_must_be_positive_int', 'offset', 'label_spacing'));
     }
 
-    if (config.show_wind?.includes('barb') && typeof forecast[0].wind_bearing === 'string') {
+    if (config.show_wind?.includes('barb') && typeof forecast?.[0].wind_bearing === 'string') {
       return await this._showError(this.localize('errors.no_wind_barbs_with_string_bearing'));
     }
 
@@ -282,7 +360,6 @@ export class HourlyWeatherCard extends LitElement {
         </ha-card>`;
     }
 
-    const isForecastDaily = this.isForecastDaily(forecast);
     const conditionList = this.getConditionListFromForecast(forecast, numSegments, offset);
     const temperatures = this.getTemperatures(forecast, numSegments, offset);
     const wind = this.getWind(forecast, numSegments, offset, windSpeedUnit);
@@ -302,8 +379,6 @@ export class HourlyWeatherCard extends LitElement {
         .label=${`Hourly Weather: ${config.entity || 'No Entity Defined'}`}
       >
         <div class="card-content">
-          ${isForecastDaily ?
-        this._showWarning(this.localize('errors.daily_forecasts')) : ''}
           ${colorSettings.warnings.length ?
         this._showWarning(this.localize('errors.invalid_colors') + ' ' + colorSettings.warnings.join(', ')) : ''}
           <!-- @ts-ignore -->
@@ -430,12 +505,6 @@ export class HourlyWeatherCard extends LitElement {
         return speed * 0.51444444444444;
     }
     return -1;
-  }
-
-  private isForecastDaily(forecast: ForecastSegment[]): boolean {
-    const dates = forecast.map(f => new Date(f.datetime).getDate());
-    const uniqueDates = new Set(dates);
-    return uniqueDates.size >= forecast.length - 1;
   }
 
   private formatHour(time: Date, locale: FrontendLocaleData): string {

--- a/src/localize/languages/da.json
+++ b/src/localize/languages/da.json
@@ -28,7 +28,6 @@
     "errors": {
       "missing_entity": "entitet mangler i konfiguration",
       "too_many_segments_requested": "For mange segmenter forespurgt i num_segments. Skal være mindre eller lig antal segmenter i vejrudsigtsentiteten.",
-      "daily_forecasts": "Den valgte vejrudsigtsentitet ser ud til at have daglige vejrudsigter. Overvej at skifte til en med timeudsigter.",
       "must_be_int": "Skal være et heltal størrere end eller lig 2",
       "invalid_colors": "Føglende farver i din konfiguration er ugyldige:",
       "must_be_positive_int": "Skal være et positivt heltal",

--- a/src/localize/languages/da.json
+++ b/src/localize/languages/da.json
@@ -1,75 +1,77 @@
 {
-    "common": {
-      "version": "Version",
-      "title": "Time Vejr",
-      "title_card": "Time Vejr Kort",
-      "description": "Et kort som viser vejret hver time som en linje.",
-      "invalid_configuration": "Ugyldig konfiguration"
-    },
-    "editor": {
-      "entity": "Entitet (Påkrævet)",
-      "name": "Navn (Valgfri)",
-      "segments_to_show": "Antal udsigtssegmenter der skal vises (Valgfri)",
-      "offset": "Antal udsigtssegmenter starten skal forskydes (Valgfri)",
-      "icons": "Vis ikoner i stedet for tekst",
-      "label_spacing": "Antal segmenter imellem tid og temperatur labels (Valgfri)",
-      "show_wind": "Vis vindhastighed og retning",
-      "show_precipitation_amounts": "Vis nedbørsmængde",
-      "show_precipitation_probability": "Vis nedbørssandsynlighed",
-      "none": "Ingen",
-      "speed_and_direction": "Hastighed og retning",
-      "speed_only": "Kun hastighed",
-      "direction_only": "Kun retning",
-      "barb": "Som vindrose",
-      "barb_and_speed": "Som vindrose og hastighed",
-      "barb_and_direction": "Som vindrose og retning",
-      "barb_speed_and_direction": "Som vindrose, hastighed, og retning"
-    },
-    "errors": {
-      "missing_entity": "entitet mangler i konfiguration",
-      "too_many_segments_requested": "For mange segmenter forespurgt i num_segments. Skal være mindre eller lig antal segmenter i vejrudsigtsentiteten.",
-      "must_be_int": "Skal være et heltal størrere end eller lig 2",
-      "invalid_colors": "Føglende farver i din konfiguration er ugyldige:",
-      "must_be_positive_int": "Skal være et positivt heltal",
-      "offset_must_be_positive_int": "offset skal være et positivt heltal",
-      "forecast_not_available": "Vejrudsigt ikke tilgængelig",
-      "check_entity": "Kontroller den definerede vejrudsigtsentitet.",
-      "no_wind_barbs_with_string_bearing": "Vindrose understøttes ikke, når vejrudsigtsentitet bruger kompasretninger for vindretning."
-    },
-    "conditions": {
-      "clear": "Klart",
-      "cloudy": "Skyet",
-      "fog": "Tåge",
-      "hail": "Hagl",
-      "thunderstorm": "Torden",
-      "partlyCloudy": "Delvist overskyet",
-      "heavyRain": "Kraftig regn",
-      "rain": "Regn",
-      "snow": "Sne",
-      "mixedPrecip": "Blandet nedbør",
-      "sunny": "Sol",
-      "windy": "Blæsende"
-    },
-    "direction": {
-      "n": "N",
-      "nne": "NNØ",
-      "ne": "NØ",
-      "ene": "ØNØ",
-      "e": "Ø",
-      "ese": "ØSØ",
-      "se": "SØ",
-      "sse": "SSØ",
-      "s": "S",
-      "ssw": "SSV",
-      "sw": "SV",
-      "wsw": "VSV",
-      "w": "V",
-      "wnw": "VNV",
-      "nw": "NV",
-      "nnw": "NNV"
-    },
-    "card": {
-      "chance_of_precipitation": "{0}% risiko for nedbør"
-    }
+  "common": {
+    "version": "Version",
+    "title": "Time Vejr",
+    "title_card": "Time Vejr Kort",
+    "description": "Et kort som viser vejret hver time som en linje.",
+    "invalid_configuration": "Ugyldig konfiguration"
+  },
+  "editor": {
+    "entity": "Entitet (Påkrævet)",
+    "name": "Navn (Valgfri)",
+    "segments_to_show": "Antal udsigtssegmenter der skal vises (Valgfri)",
+    "offset": "Antal udsigtssegmenter starten skal forskydes (Valgfri)",
+    "icons": "Vis ikoner i stedet for tekst",
+    "label_spacing": "Antal segmenter imellem tid og temperatur labels (Valgfri)",
+    "show_wind": "Vis vindhastighed og retning",
+    "show_precipitation_amounts": "Vis nedbørsmængde",
+    "show_precipitation_probability": "Vis nedbørssandsynlighed",
+    "none": "Ingen",
+    "speed_and_direction": "Hastighed og retning",
+    "speed_only": "Kun hastighed",
+    "direction_only": "Kun retning",
+    "barb": "Som vindrose",
+    "barb_and_speed": "Som vindrose og hastighed",
+    "barb_and_direction": "Som vindrose og retning",
+    "barb_speed_and_direction": "Som vindrose, hastighed, og retning",
+    "show_date": "Vis datoer",
+    "all": "Alle",
+    "on_day_boundaries": "På dagsgrænser"
+  },
+  "errors": {
+    "missing_entity": "entitet mangler i konfiguration",
+    "too_many_segments_requested": "For mange segmenter forespurgt i num_segments. Skal være mindre eller lig antal segmenter i vejrudsigtsentiteten.",
+    "must_be_int": "Skal være et heltal størrere end eller lig 2",
+    "invalid_colors": "Føglende farver i din konfiguration er ugyldige:",
+    "must_be_positive_int": "Skal være et positivt heltal",
+    "offset_must_be_positive_int": "offset skal være et positivt heltal",
+    "forecast_not_available": "Vejrudsigt ikke tilgængelig",
+    "check_entity": "Kontroller den definerede vejrudsigtsentitet.",
+    "no_wind_barbs_with_string_bearing": "Vindrose understøttes ikke, når vejrudsigtsentitet bruger kompasretninger for vindretning."
+  },
+  "conditions": {
+    "clear": "Klart",
+    "cloudy": "Skyet",
+    "fog": "Tåge",
+    "hail": "Hagl",
+    "thunderstorm": "Torden",
+    "partlyCloudy": "Delvist overskyet",
+    "heavyRain": "Kraftig regn",
+    "rain": "Regn",
+    "snow": "Sne",
+    "mixedPrecip": "Blandet nedbør",
+    "sunny": "Sol",
+    "windy": "Blæsende"
+  },
+  "direction": {
+    "n": "N",
+    "nne": "NNØ",
+    "ne": "NØ",
+    "ene": "ØNØ",
+    "e": "Ø",
+    "ese": "ØSØ",
+    "se": "SØ",
+    "sse": "SSØ",
+    "s": "S",
+    "ssw": "SSV",
+    "sw": "SV",
+    "wsw": "VSV",
+    "w": "V",
+    "wnw": "VNV",
+    "nw": "NV",
+    "nnw": "NNV"
+  },
+  "card": {
+    "chance_of_precipitation": "{0}% risiko for nedbør"
   }
-  
+}

--- a/src/localize/languages/de.json
+++ b/src/localize/languages/de.json
@@ -27,7 +27,6 @@
   },
   "errors": {
     "missing_entity": "Keine Wetter-Entität festgelegt",
-    "daily_forecasts": "Die gewählte Wetter-Entität scheint tägliche Vorhersagen zu liefern. Bitte eine Wetter-Entität mit stündlicher Vorhersage wählen.",
     "must_be_int": "Muss eine gerade ganze Zahl größer oder gleich 2 sein.",
     "invalid_colors": "Die folgenden Farben in Ihrer Konfiguration sind ungültig:",
     "must_be_positive_int": "Muss eine positive Ganzzahl sein",

--- a/src/localize/languages/de.json
+++ b/src/localize/languages/de.json
@@ -23,7 +23,10 @@
     "speed_and_direction": "Geschwindigkeit und Richtung",
     "barb_and_speed": "Als Windwiderhaken und Geschwindigkeit",
     "barb_and_direction": "Als Windwiderhaken und Richtung",
-    "barb_speed_and_direction": "Als Windwiderstand, Geschwindigkeit und Richtung"
+    "barb_speed_and_direction": "Als Windwiderstand, Geschwindigkeit und Richtung",
+    "show_date": "Termine anzeigen",
+    "all": "Alle",
+    "on_day_boundaries": "An Tagesgrenzen"
   },
   "errors": {
     "missing_entity": "Keine Wetter-Entität festgelegt",

--- a/src/localize/languages/en.json
+++ b/src/localize/languages/en.json
@@ -14,6 +14,7 @@
     "icons": "Show icons instead of text labels",
     "label_spacing": "Number of forecast segments to space time and temperature labels by (Optional)",
     "show_wind": "Show wind speed and direction",
+    "show_date": "Show dates",
     "show_precipitation_amounts": "Show precipitation amount",
     "show_precipitation_probability": "Show precipitation probability",
     "none": "None",
@@ -23,12 +24,13 @@
     "barb": "As wind barb",
     "barb_and_speed": "As wind barb and speed",
     "barb_and_direction": "As wind barb and direction",
-    "barb_speed_and_direction": "As wind barb, speed, and direction"
+    "barb_speed_and_direction": "As wind barb, speed, and direction",
+    "all": "All",
+    "on_day_boundaries": "On day boundaries"
   },
   "errors": {
     "missing_entity": "entity is missing in configuration",
     "too_many_segments_requested": "Too many forecast segments requested in num_segments. Must be <= number of segments in forecast entity.",
-    "daily_forecasts": "The selected weather entity seems to provide daily forecasts. Consider switching to an hourly entity.",
     "must_be_int": "Must be an even integer greater than or equal to 2",
     "invalid_colors": "The following colors in your configuration are invalid:",
     "must_be_positive_int": "Must be a positive integer",

--- a/src/localize/languages/es.json
+++ b/src/localize/languages/es.json
@@ -27,7 +27,6 @@
   },
   "errors": {
     "missing_entity": "falta la entidad en la configuración",
-    "daily_forecasts": "La entidad seleccionada parece proveer pronósticos diarios. Considera cambiar a una entidad que provea pronósticos cada hora.",
     "must_be_int": "Debe ser un entero mayor o igual a 2",
     "invalid_colors": "Los siguientes colores en su configuración no son válidos:",
     "must_be_positive_int": "Debe ser un entero positivo",

--- a/src/localize/languages/es.json
+++ b/src/localize/languages/es.json
@@ -23,7 +23,10 @@
     "speed_and_direction": "Velocidad y dirección",
     "barb_and_speed": "Como púas de viento y velocidad",
     "barb_and_direction": "Como púa de viento y dirección",
-    "barb_speed_and_direction": "Como púa de viento, velocidad y dirección"
+    "barb_speed_and_direction": "Como púa de viento, velocidad y dirección",
+    "show_date": "Mostrar fechas",
+    "all": "Todo",
+    "on_day_boundaries": "En los límites del día"
   },
   "errors": {
     "missing_entity": "falta la entidad en la configuración",

--- a/src/localize/languages/fr.json
+++ b/src/localize/languages/fr.json
@@ -27,7 +27,6 @@
   },
   "errors": {
     "missing_entity": "Entité manquante dans la configuration",
-    "daily_forecasts": "L'entité sélectionnée semble fournir des prévisions quotidiennes. Envisagez de passer à une entité fournissant des prévisions par heure.",
     "must_be_int": "Doit être un nombre entier pair supérieur ou égal à 2",
     "invalid_colors": "Les couleurs suivantes dans votre configuration ne sont pas valides :",
     "must_be_positive_int": "Doit être un entier positif",

--- a/src/localize/languages/fr.json
+++ b/src/localize/languages/fr.json
@@ -23,7 +23,10 @@
     "speed_and_direction": "Vitesse et orientation",
     "barb_and_speed": "Comme barbe de vent et vitesse",
     "barb_and_direction": "Comme barbillon de vent et direction",
-    "barb_speed_and_direction": "Comme barbillon de vent, vitesse et direction"
+    "barb_speed_and_direction": "Comme barbillon de vent, vitesse et direction",
+    "show_date": "Afficher les dates",
+    "all": "Tous",
+    "on_day_boundaries": "Aux limites du jour"
   },
   "errors": {
     "missing_entity": "Entité manquante dans la configuration",

--- a/src/localize/languages/hu.json
+++ b/src/localize/languages/hu.json
@@ -23,7 +23,10 @@
     "speed_and_direction": "Sebesség és irány",
     "barb_and_speed": "Szélfogóként és sebességként",
     "barb_and_direction": "Szellőként és irányként",
-    "barb_speed_and_direction": "Szélfogként, sebességként és irányként"
+    "barb_speed_and_direction": "Szélfogként, sebességként és irányként",
+    "show_date": "Dátumok megjelenítése",
+    "all": "Minden",
+    "on_day_boundaries": "A napok határain"
   },
   "errors": {
     "missing_entity": "az entitás hiányzik a konfigurációból",

--- a/src/localize/languages/hu.json
+++ b/src/localize/languages/hu.json
@@ -28,7 +28,6 @@
   "errors": {
     "missing_entity": "az entitás hiányzik a konfigurációból",
     "too_many_segments_requested": "Túl sok előrejelzési órát adtak meg a num_segments-ben. <= az előrejelző egységben lévő órák száma.",
-    "daily_forecasts": "Úgy tűnik, hogy a kiválasztott időjárási egység napi előrejelzéseket ad. Fontolja meg a váltást egy óránkénti egységre.",
     "must_be_int": "Páros egész számnak kell lennie, amely nagyobb vagy egyenlő 2-nél.",
     "invalid_colors": "A konfigurációdban a következő színek érvénytelenek:",
     "must_be_positive_int": "Pozitív egész szám kell legyen",

--- a/src/localize/languages/it.json
+++ b/src/localize/languages/it.json
@@ -23,7 +23,10 @@
     "speed_and_direction": "Velocità e direzione",
     "barb_and_speed": "Come il vento tagliente e la velocità",
     "barb_and_direction": "Come il vento e la direzione",
-    "barb_speed_and_direction": "Come la punta del vento, la velocità e la direzione"
+    "barb_speed_and_direction": "Come la punta del vento, la velocità e la direzione",
+    "show_date": "Mostra date",
+    "all": "Tutto",
+    "on_day_boundaries": "Sui confini del giorno"
   },
   "errors": {
     "missing_entity": "entità mancante nella configurazione",

--- a/src/localize/languages/it.json
+++ b/src/localize/languages/it.json
@@ -27,7 +27,6 @@
   },
   "errors": {
     "missing_entity": "entità mancante nella configurazione",
-    "daily_forecasts": "L'entità meteo selezionata sembra fornire previsioni giornaliere. Prendi in considerazione il passaggio a un'entità oraria.",
     "must_be_int": "Deve essere un numero intero pari, maggiore o uguale a 2",
     "invalid_colors": "I seguenti colori nella tua configurazione non sono validi:",
     "must_be_positive_int": "Deve essere un numero intero positivo",

--- a/src/localize/languages/nb.json
+++ b/src/localize/languages/nb.json
@@ -23,7 +23,10 @@
     "speed_and_direction": "Fart og retning",
     "barb_and_speed": "Som vindmottak og fart",
     "barb_and_direction": "Som vindmottak og retning",
-    "barb_speed_and_direction": "Som vindmothak, hastighet og retning"
+    "barb_speed_and_direction": "Som vindmothak, hastighet og retning",
+    "show_date": "Vis datoer",
+    "all": "Alle",
+    "on_day_boundaries": "På dagsgrenser"
   },
   "errors": {
     "missing_entity": "entity mangler i konfigurasjonen",

--- a/src/localize/languages/nb.json
+++ b/src/localize/languages/nb.json
@@ -27,7 +27,6 @@
   },
   "errors": {
     "missing_entity": "entity mangler i konfigurasjonen",
-    "daily_forecasts": "Den valgte værenheten ser ut til å gi daglige prognoser. Vurder å bytte til en timebasert enhet.",
     "must_be_int": "Må være et jevnt heltall større enn eller lik 2",
     "invalid_colors": "Følgende farger i konfigurasjonen din er ugyldige:",
     "must_be_positive_int": "Må være et positivt heltall",

--- a/src/localize/languages/nl.json
+++ b/src/localize/languages/nl.json
@@ -23,7 +23,10 @@
     "speed_and_direction": "Snelheid en richting",
     "barb_and_speed": "Zoals wind weerhaak en snelheid",
     "barb_and_direction": "Als windhaak en richting",
-    "barb_speed_and_direction": "Zoals wind weerhaak, snelheid en richting"
+    "barb_speed_and_direction": "Zoals wind weerhaak, snelheid en richting",
+    "show_date": "Datums weergeven",
+    "all": "Alle",
+    "on_day_boundaries": "Op daggrenzen"
   },
   "errors": {
     "missing_entity": "entiteit ontbreekt in configuratie",

--- a/src/localize/languages/nl.json
+++ b/src/localize/languages/nl.json
@@ -28,7 +28,6 @@
   "errors": {
     "missing_entity": "entiteit ontbreekt in configuratie",
     "too_many_segments_requested": "Te veel prognosesegmenten aangevraagd in num_segments. Moet <= aantal segmenten in prognose-entiteit zijn.",
-    "daily_forecasts": "De geselecteerde weereenheid lijkt dagelijkse voorspellingen te geven. Overweeg om over te stappen naar een voorspelling op uurbasis.",
     "must_be_int": "Moet een even geheel getal zijn groter of gelijk aan 2",
     "invalid_colors": "De volgende kleuren in uw configuratie zijn ongeldig:",
     "must_be_positive_int": "Moet een positief geheel getal zijn",

--- a/src/localize/languages/nn-NO.json
+++ b/src/localize/languages/nn-NO.json
@@ -29,7 +29,6 @@
   },
   "errors": {
     "missing_entity": "entity manglar i konfigurasjonen",
-    "daily_forecasts": "Den valde vereininga ser ut til å gje daglege prognoser. Vurder å byte til ein timebasert eining.",
     "must_be_int": "Må være et jevnt heiltal større enn eller lik 2",
     "invalid_colors": "Følgande fargar i konfigurasjonen din er ugyldege:",
     "must_be_positive_int": "Må vere eit positivt heiltal",

--- a/src/localize/languages/nn-NO.json
+++ b/src/localize/languages/nn-NO.json
@@ -25,7 +25,10 @@
     "speed_and_direction": "Fart og retning",
     "barb_and_speed": "Som vindmottak og fart",
     "barb_and_direction": "Som vindmottak og retning",
-    "barb_speed_and_direction": "Som vindmothak, hastighet og retning"
+    "barb_speed_and_direction": "Som vindmothak, hastighet og retning",
+    "show_date": "Vis datoer",
+    "all": "Alle",
+    "on_day_boundaries": "På dagsgrenser"
   },
   "errors": {
     "missing_entity": "entity manglar i konfigurasjonen",

--- a/src/localize/languages/pl.json
+++ b/src/localize/languages/pl.json
@@ -27,7 +27,6 @@
   },
   "errors": {
     "missing_entity": "encja nie istnieje",
-    "daily_forecasts": "Wybrana encja dostarcza pogodę dniową, wybierz encję z pogodą godzinową.",
     "must_be_int": "Musi być parzystą liczbą całkowitą większą lub równą 2",
     "invalid_colors": "Następujące kolory w Twojej konfiguracji są nieprawidłowe:",
     "must_be_positive_int": "Musi być dodatnią liczbą całkowitą",

--- a/src/localize/languages/pl.json
+++ b/src/localize/languages/pl.json
@@ -23,7 +23,10 @@
     "speed_and_direction": "Szybkość i kierunek",
     "barb_and_speed": "Jak kolce wiatru i prędkość",
     "barb_and_direction": "Jako zadzior i kierunek wiatru",
-    "barb_speed_and_direction": "Jak kolce wiatru, prędkość i kierunek"
+    "barb_speed_and_direction": "Jak kolce wiatru, prędkość i kierunek",
+    "show_date": "Pokaż daty",
+    "all": "Wszystko",
+    "on_day_boundaries": "Na granicach dnia"
   },
   "errors": {
     "missing_entity": "encja nie istnieje",

--- a/src/localize/languages/pt-BR.json
+++ b/src/localize/languages/pt-BR.json
@@ -25,7 +25,10 @@
     "speed_and_direction": "Velocidade e direção",
     "barb_and_speed": "Como farpa de vento e velocidade",
     "barb_and_direction": "Como farpa de vento e direção",
-    "barb_speed_and_direction": "Como farpa de vento, velocidade e direção"
+    "barb_speed_and_direction": "Como farpa de vento, velocidade e direção",
+    "show_date": "Mostrar datas",
+    "all": "Todos",
+    "on_day_boundaries": "Nos limites do dia"
   },
   "errors": {
     "missing_entity": "entidade está faltando na configuração",

--- a/src/localize/languages/pt-BR.json
+++ b/src/localize/languages/pt-BR.json
@@ -30,7 +30,6 @@
   "errors": {
     "missing_entity": "entidade está faltando na configuração",
     "too_many_segments_requested": "Muitos segmentos de previsão solicitados em num_segments. Deve ser <= número de segmentos na entidade de previsão.",
-    "daily_forecasts": "A entidade meteorológica selecionada parece fornecer previsões diárias. Considere mudar para uma entidade horária.",
     "must_be_int": "Deve ser um número inteiro par maior ou igual a 2",
     "invalid_colors": "As seguintes cores em sua configuração são inválidas:",
     "must_be_positive_int": "Deve ser um número inteiro positivo",

--- a/src/localize/languages/pt.json
+++ b/src/localize/languages/pt.json
@@ -27,7 +27,6 @@
   },
   "errors": {
     "missing_entity": "A entidade não existe na configuração",
-    "daily_forecasts": "A entidade meteorológica selecionada parece fornecer previsões diárias. Considere mudar para uma entidade horária.",
     "must_be_int": "Deve ser um número inteiro par maior ou igual a 2",
     "invalid_colors": "As seguintes cores em sua configuração são inválidas:",
     "must_be_positive_int": "Deve ser um número inteiro positivo",

--- a/src/localize/languages/pt.json
+++ b/src/localize/languages/pt.json
@@ -23,7 +23,10 @@
     "speed_and_direction": "Velocidade e direção",
     "barb_and_speed": "Como farpa de vento e velocidade",
     "barb_and_direction": "Como farpa de vento e direção",
-    "barb_speed_and_direction": "Como farpa de vento, velocidade e direção"
+    "barb_speed_and_direction": "Como farpa de vento, velocidade e direção",
+    "show_date": "Mostrar datas",
+    "all": "Todos",
+    "on_day_boundaries": "Nos limites do dia"
   },
   "errors": {
     "missing_entity": "A entidade não existe na configuração",

--- a/src/localize/languages/sk.json
+++ b/src/localize/languages/sk.json
@@ -23,7 +23,10 @@
     "barb": "Ako veterný osteň",
     "barb_and_speed": "Ako veterný osteň a rýchlosť",
     "barb_and_direction": "Ako veterný osteň a smer",
-    "barb_speed_and_direction": "Ako veterný osteň, rýchlosť a smer"
+    "barb_speed_and_direction": "Ako veterný osteň, rýchlosť a smer",
+    "show_date": "Zobraziť dátumy",
+    "all": "Všetky",
+    "on_day_boundaries": "Na hraniciach dňa"
   },
   "errors": {
     "missing_entity": "v konfigurácii chýba entita",

--- a/src/localize/languages/sk.json
+++ b/src/localize/languages/sk.json
@@ -28,7 +28,6 @@
   "errors": {
     "missing_entity": "v konfigurácii chýba entita",
     "too_many_segments_requested": "Príliš veľa segmentov prognózy požadovaných v num_segments. Musí byť <= počet segmentov v entite prognózy.",
-    "daily_forecasts": "Zdá sa, že vybratá entita počasia poskytuje denné predpovede. Zvážte prechod na hodinovú entitu.",
     "must_be_int": "Musí byť párne celé číslo väčšie alebo rovné 2",
     "invalid_colors": "Nasledujúce farby vo vašej konfigurácii sú neplatné:",
     "must_be_positive_int": "Musí to byť kladné celé číslo",

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,7 +24,7 @@ export interface HourlyWeatherCardConfig extends LovelaceCardConfig {
   hide_bar?: boolean;
   hide_hours?: boolean;
   hide_temperatures?: boolean;
-  show_wind?: WindType; // 'true' | 'false' | 'speed' | 'direction' | 'barb' | 'barb-and-speed' | 'barb-and-direction' | 'barb-speed-and-direction'
+  show_wind?: WindType | boolean; // 'true' | 'false' | 'speed' | 'direction' | 'barb' | 'barb-and-speed' | 'barb-and-direction' | 'barb-speed-and-direction'
   show_precipitation_amounts?: boolean;
   show_precipitation_probability?: boolean;
   show_date?: ShowDateType; // 'false' | 'boundary' | 'all'

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,6 +16,7 @@ export interface HourlyWeatherCardConfig extends LovelaceCardConfig {
   /** @deprecated Use num_segments instead */
   num_hours?: string; // number
   num_segments?: string; // number
+  forecast_type?: ForecastType;
   name?: string;
   icons?: boolean;
   offset?: string; // number
@@ -112,4 +113,11 @@ export interface RenderTemplateResult {
 export interface LocalizerLastSettings {
   configuredLanguage: string | undefined,
   haServerLanguage: string | undefined
+}
+
+export type ForecastType = "hourly" | "daily" | "twice_daily";
+
+export interface ForecastEvent {
+  type: ForecastType;
+  forecast: [ForecastSegment] | null;
 }


### PR DESCRIPTION
Home Assistant [shipped](https://developers.home-assistant.io/blog/2023/08/07/weather_entity_forecast_types) a new mechanism for forecast data loading in 2023.9.0. tl;dr: the `forecast` attribute is deprecated and cards should move to the `weather/get_forecast` web service to get and update weather forecast data.

This PR adds support for that mechanism while maintaining the older mechanism as a fallback. It also removes the warnings when using daily forecasts since that's now less of a crummy experience given the `show_date` config setting. I've also promoted the `show_date` config option into the editor. If you are using daily forecasts, you may wish to show all dates and then hide the hours (`hide_hours` is YAML only right now).

I'll release this as a beta from this branch to make sure things still work with HA versions prior to 2023.9.0.

This PR also contains a fix for #509 by allowing the `show_wind` config option to be a boolean.

Fixes #503, #509