### PR TITLE
handle weather forecast callback delay #586

### DIFF
--- a/cypress/e2e/card.cy.ts
+++ b/cypress/e2e/card.cy.ts
@@ -49,4 +49,63 @@ describe('Card', () => {
       .find('p')
       .should('have.text', 'Check the configured forecast entity.');
   });
+  it('handles graceful transient error if forecast is there by attribute, but not with the right amount of segments', () => {
+    cy.enableForecastSubscriptions();
+
+    const forecast1 = [
+      {
+        "datetime": "2022-07-21T17:00:00+00:00",
+        "precipitation": 0,
+        "precipitation_probability": 0,
+        "pressure": 1007,
+        "wind_speed": 4.67,
+        "wind_bearing": 'WSW',
+        "condition": "cloudy",
+        "clouds": 60,
+        "temperature": 84
+      },
+    ];
+    cy.addEntity({
+      'weather.fromSub': {
+        attributes: {
+          forecast: forecast1
+        }
+      }
+    });    
+    cy.configure({
+      entity: 'weather.fromSub',
+      num_segments: '2'
+    });
+    cy.get('ha-card')
+      .should('not.exist');
+
+    const forecast2 = [
+      {
+        "datetime": "2022-07-21T17:00:00+00:00",
+        "precipitation": 0,
+        "precipitation_probability": 0,
+        "pressure": 1007,
+        "wind_speed": 4.67,
+        "wind_bearing": 'WSW',
+        "condition": "cloudy",
+        "clouds": 60,
+        "temperature": 84
+      },
+      {
+        "datetime": "2022-07-21T17:00:00+00:00",
+        "precipitation": 0,
+        "precipitation_probability": 0,
+        "pressure": 1007,
+        "wind_speed": 4.67,
+        "wind_bearing": 'WSW',
+        "condition": "cloudy",
+        "clouds": 60,
+        "temperature": 84
+      }
+    ];
+    cy.addForecast('weather.fromSub', forecast2);
+    cy.updateLastForecastSubscription(forecast2);
+    cy.get('ha-card')
+      .should('exist');
+  });
 });

--- a/src/hourly-weather.ts
+++ b/src/hourly-weather.ts
@@ -313,7 +313,7 @@ export class HourlyWeatherCard extends LitElement {
 
     const entityId: string = config.entity;
     const state = this.hass.states[entityId];
-    const {forecast, pending} = this.getForecast();
+    const { forecast, pending } = this.getForecast();
     const windSpeedUnit = state.attributes.wind_speed_unit ?? '';
     const precipitationUnit = state.attributes.precipitation_unit ?? '';
     const numSegments = parseInt(config.num_segments ?? config.num_hours ?? '12', 10);

--- a/src/hourly-weather.ts
+++ b/src/hourly-weather.ts
@@ -289,7 +289,7 @@ export class HourlyWeatherCard extends LitElement {
   }
 
   private getForecast(): { forecast: ForecastSegment[] | undefined, pending: boolean } {
-    const pending = !this.forecastEvent?.forecast;
+    const pending = !this.forecastEvent?.forecast && this.hassSupportsForecastEvents();
     const forecast = this.forecastEvent?.forecast ?? this.hass?.states[this.config.entity]?.attributes.forecast;
     return { forecast, pending };
   }
@@ -322,13 +322,11 @@ export class HourlyWeatherCard extends LitElement {
     const forecastNotAvailable = !forecast || !forecast.length;
 
     if (numSegments < 1) {
-      if (pending) return;
       // REMARK: Ok, so I'm re-using a localized string here. Probably not the best, but it avoids repeating for no good reason
       return await this._showError(this.localize('errors.offset_must_be_positive_int', 'offset', 'num_segments'));
     }
 
     if (offset < 0) {
-      if (pending) return;
       return await this._showError(this.localize('errors.offset_must_be_positive_int'));
     }
 


### PR DESCRIPTION
I have added pending temporary state - until the callback is not returned - to skip rendering any error messages in this state #586.

Please comment / modify if you see any better approach to circumvent the problem (e.g. delayed rendering).