### PR TITLE
Do not call forecast service for non-weather entities

### DIFF
--- a/src/hourly-weather.ts
+++ b/src/hourly-weather.ts
@@ -142,7 +142,7 @@ export class HourlyWeatherCard extends LitElement {
 
   private async subscribeToForecastEvents() {
     this.unsubscribeForecastEvents();
-    if (!this.isConnected || !this.hass || !this.config || !this.config.entity || !this.hassSupportsForecastEvents()) {
+    if (!this.isConnected || !this.hass || !this.config || !this.config.entity || !this.hassSupportsForecastEvents() || !this.config.entity.startsWith('weather.')) {
       return;
     }
 


### PR DESCRIPTION
Avoid making the forecast service call if the configured entity is not a weather kind (see linked issue)

Resolves #677 