### PR TITLE
Compatibility fix for Home Assistant Core 2024.7

### DIFF
--- a/cypress/fixtures/harness.html
+++ b/cypress/fixtures/harness.html
@@ -607,7 +607,7 @@
         ...h.hass,
         services: {
           weather: {
-            get_forecast: () => {}
+            get_forecasts: () => {}
           }
         }
       };

--- a/package-lock.json
+++ b/package-lock.json
@@ -2838,12 +2838,12 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -4496,9 +4496,9 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"

--- a/src/hourly-weather.ts
+++ b/src/hourly-weather.ts
@@ -295,7 +295,7 @@ export class HourlyWeatherCard extends LitElement {
   }
 
   private hassSupportsForecastEvents(): boolean {
-    return !!(this.hass?.services?.weather?.get_forecast);
+    return !!(this.hass?.services?.weather?.get_forecasts);
   }
 
   // https://lit.dev/docs/components/rendering/

--- a/src/hourly-weather.ts
+++ b/src/hourly-weather.ts
@@ -295,7 +295,7 @@ export class HourlyWeatherCard extends LitElement {
   }
 
   private hassSupportsForecastEvents(): boolean {
-    return !!(this.hass?.services?.weather?.get_forecasts);
+    return !!(this.hass?.services?.weather?.get_forecasts) || !!(this.hass?.services?.weather?.get_forecast);
   }
 
   // https://lit.dev/docs/components/rendering/


### PR DESCRIPTION
Fixes #704 

Home Assistant Core 2024.7 drops the deprecated `get_forecast` service. This card was using the existence of that service to determine whether to use the more modern web socket subscription mechanism of retrieving forecasts or to use the older `forecast` attribute on the entity. The fix is simply to look for either the older `get_forecast` OR the newer `get_forecasts` for this check.