### PR TITLE
[#830] Fix rounding with non-period decimal separators

### DIFF
--- a/cypress/e2e/internationalization.cy.ts
+++ b/cypress/e2e/internationalization.cy.ts
@@ -88,7 +88,7 @@ describe('Internationalization', () => {
               "wind_bearing": 255,
               "condition": "cloudy",
               "clouds": 60,
-              "temperature": 84.2
+              "temperature": 83.6
             },
             {
               "datetime": "2022-07-21T18:00:00+00:00",
@@ -99,7 +99,7 @@ describe('Internationalization', () => {
               "wind_bearing": 253,
               "condition": "cloudy",
               "clouds": 75,
-              "temperature": 85.5
+              "temperature": 85.6
             },
             {
               "datetime": "2022-07-21T19:00:00+00:00",
@@ -110,7 +110,7 @@ describe('Internationalization', () => {
               "wind_bearing": 258,
               "condition": "cloudy",
               "clouds": 60,
-              "temperature": 85.3
+              "temperature": 85.6
             },
             {
               "datetime": "2022-07-21T20:00:00+00:00",
@@ -162,7 +162,7 @@ describe('Internationalization', () => {
         .shadow()
         .find('div.axes > div.bar-block div.temperature')
         .first()
-        .should('have.text', '84.2°');
+        .should('have.text', '83.6°');
     });
     it('uses comma as decimal separator when specified as decimal_comma', () => {
       cy.setLocale({
@@ -172,7 +172,7 @@ describe('Internationalization', () => {
         .shadow()
         .find('div.axes > div.bar-block div.temperature')
         .first()
-        .should('have.text', '84,2°');
+        .should('have.text', '83,6°');
     });
     it('uses comma as decimal separator when specified as space_comma', () => {
       cy.setLocale({
@@ -182,7 +182,22 @@ describe('Internationalization', () => {
         .shadow()
         .find('div.axes > div.bar-block div.temperature')
         .first()
-        .should('have.text', '84,2°');
+        .should('have.text', '83,6°');
+    });
+    it('rounds properly when number format uses a comma', () => {
+      cy.configure({
+        entity: 'weather.fractional',
+        num_segments: '6',
+        round_temperatures: true,
+      });
+      cy.setLocale({
+        number_format: 'decimal_comma'
+      });
+      cy.get('weather-bar')
+        .shadow()
+        .find('div.axes > div.bar-block div.temperature')
+        .first()
+        .should('have.text', '84°');
     });
   });
 });

--- a/src/hourly-weather.ts
+++ b/src/hourly-weather.ts
@@ -323,6 +323,7 @@ export class HourlyWeatherCard extends LitElement {
     const forecastNotAvailable = !forecast || !forecast.length;
     const icon_fill = config.icon_fill;
     const hideMinutes = !!config.hide_minutes;
+    const roundTemperatures = !!config.round_temperatures;
 
     if (numSegments < 1) {
       // REMARK: Ok, so I'm re-using a localized string here. Probably not the best, but it avoids repeating for no good reason
@@ -379,7 +380,7 @@ export class HourlyWeatherCard extends LitElement {
     }
 
     const conditionList = this.getConditionListFromForecast(forecast, numSegments, offset);
-    const temperatures = this.getTemperatures(forecast, numSegments, offset, hideMinutes);
+    const temperatures = this.getTemperatures(forecast, numSegments, offset, hideMinutes, roundTemperatures);
     const wind = this.getWind(forecast, numSegments, offset, windSpeedUnit, hideMinutes);
     const precipitation = this.getPrecipitation(forecast, numSegments, offset, precipitationUnit, hideMinutes);
 
@@ -410,7 +411,6 @@ export class HourlyWeatherCard extends LitElement {
             .colors=${colorSettings.validColors}
             .hide_hours=${!!config.hide_hours}
             .hide_temperatures=${!!config.hide_temperatures}
-            .round_temperatures=${!!config.round_temperatures}
             .hide_bar=${!!config.hide_bar}
             .icon_fill=${config.icon_fill}
             .show_wind=${showWind}
@@ -441,15 +441,18 @@ export class HourlyWeatherCard extends LitElement {
     return res;
   }
 
-  private getTemperatures(forecast: ForecastSegment[], numSegments: number, offset: number, hideMinutes: boolean): SegmentTemperature[] {
+  private getTemperatures(forecast: ForecastSegment[], numSegments: number, offset: number, hideMinutes: boolean, roundTemperatures: boolean): SegmentTemperature[] {
     const temperatures: SegmentTemperature[] = [];
     for (let i = offset; i < numSegments + offset; i++) {
       const fs = forecast[i];
       const dt = new Date(fs.datetime)
+      const temperature = roundTemperatures && !Number.isNaN(fs.temperature) ?
+        Math.round(fs.temperature) :
+        fs.temperature;
       temperatures.push({
         date: formatDateShort(dt, this.hass.locale),
         hour: this.formatHour(dt, this.hass.locale, hideMinutes),
-        temperature: formatNumber(fs.temperature, this.hass.locale)
+        temperature: formatNumber(temperature, this.hass.locale)
       })
     }
     return temperatures;

--- a/src/types.ts
+++ b/src/types.ts
@@ -71,40 +71,40 @@ export type ConditionSpan = [
 ]
 
 export interface SegmentTemperature {
-  hour: string,
-  date: string,
-  temperature: string
+  hour: string;
+  date: string;
+  temperature: string;
 }
 
 export interface SegmentWind {
-  hour: string,
-  windSpeed: string,
-  windSpeedRawMS: number,
-  windDirection: string,
-  windDirectionRaw: number | string
+  hour: string;
+  windSpeed: string;
+  windSpeedRawMS: number;
+  windDirection: string;
+  windDirectionRaw: number | string;
 }
 
 export interface SegmentPrecipitation {
-  hour: string,
-  precipitationAmount: string,
-  precipitationProbability: string,
-  precipitationProbabilityText: string
+  hour: string;
+  precipitationAmount: string;
+  precipitationProbability: string;
+  precipitationProbabilityText: string;
 }
 
 export type ColorMap = Map<keyof ColorConfig, ColorObject>
 
 export interface ColorSettings {
-  validColors?: ColorMap,
-  warnings: string[]
+  validColors?: ColorMap;
+  warnings: string[];
 }
 
 export interface RenderTemplateResult {
-  result: string
+  result: string;
 }
 
 export interface LocalizerLastSettings {
-  configuredLanguage: string | undefined,
-  haServerLanguage: string | undefined
+  configuredLanguage: string | undefined;
+  haServerLanguage: string | undefined;
 }
 
 export type ForecastType = "hourly" | "daily" | "twice_daily";

--- a/src/weather-bar.ts
+++ b/src/weather-bar.ts
@@ -38,9 +38,6 @@ export class WeatherBar extends LitElement {
   hide_temperatures = false;
 
   @property({ type: Boolean })
-  round_temperatures = false;
-
-  @property({ type: Boolean })
   hide_bar = false;
 
   @property({ type: String })
@@ -121,12 +118,6 @@ export class WeatherBar extends LitElement {
       const showPrecipitationAmounts = this.show_precipitation_amounts && !skipLabel;
       const showPrecipitationProbability = this.show_precipitation_probability && !skipLabel;
       const { hour, date, temperature } = this.temperatures[i];
-      const numericTemperature = parseFloat(temperature);
-      const displayTemperature = this.round_temperatures ?
-        (Number.isNaN(numericTemperature) ?
-          temperature :
-          Math.round(numericTemperature)) :
-        temperature;
       let renderedDate: string | TemplateResult | null = null;
       if (!skipLabel && this.show_date && this.show_date !== 'false') {
         if (this.show_date === 'all') renderedDate = date;
@@ -169,7 +160,7 @@ export class WeatherBar extends LitElement {
           <div class="bar-block-bottom">
             <div class="date">${renderedDate}</div>
             <div class="hour">${hideHours ? null : hour}</div>
-            <div class="temperature">${hideTemperature ? null : html`${displayTemperature}&deg;`}</div>
+            <div class="temperature">${hideTemperature ? null : html`${temperature}&deg;`}</div>
             <div class="wind">${wind}</div>
             <div class="precipitation">${precipitation}</div>
           </div>


### PR DESCRIPTION
Fixes #830 

Rounding should not have been handled in `WeatherBar`. It should have been done in the root component while `temperature` was still a number. This PR makes that right, adds a test to confirm, and also fixes some code style nits in `types.ts`.