### PR TITLE
fix: resolve day/night conditions per forecast segment

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,26 @@ label_spacing: |
 | `haptic`          | string | **Optional** | Haptic feedback _success, warning, failure, light, medium, heavy, selection_                       | `none`      |
 | `repeat`          | number | **Optional** | How often to repeat the `hold_action` in milliseconds.                                             | `none`      |
 
+## Day and night conditions
+
+Home Assistant weather integrations decide between `sunny` and `clear-night` from the sun position at the moment the
+forecast is produced, and then apply that one choice to every segment of the forecast. A forecast fetched at noon
+therefore labels tonight's clear hours `sunny`, and one fetched after dark labels tomorrow's clear hours `clear-night`.
+
+This card resolves each segment against its own timestamp instead, using your Home Assistant home location:
+
+| Reported by the integration | Sun is up      | Sun is down            |
+|-----------------------------|----------------|------------------------|
+| `sunny` / `clear-night`     | `sunny`        | `clear-night`          |
+| `partlycloudy`              | `partlycloudy` | `night-partly-cloudy`  |
+
+`night-partly-cloudy` is not a Home Assistant condition — the card derives it, because Home Assistant has no nighttime
+variant of `partlycloudy`. It can be styled and re-iconed like any other condition via [`colors`](#color-options) and
+[`icon_map`](#icon-map-options).
+
+No configuration is needed. If your `hass.config` carries no latitude and longitude, the condition reported by the
+integration is used unchanged.
+
 ## Color Options
 
 `colors` is specified as an object containing one or more of the keys listed below and values that are valid CSS
@@ -175,23 +195,24 @@ color in your Home Assistant theme.
 Some conditions will default to whatever the value is of some other condition. For example, `fog` will default to
 whatever `cloudy` is.
 
-| Key               | Default                |
-|-------------------|------------------------|
-| `clear-night`     | `#000`                 |
-| `cloudy`          | `#777`                 |
-| `fog`             | same as `cloudy`       |
-| `hail`            | `#2b5174`              |
-| `lightning`       | same as `rainy`        |
-| `lightning-rainy` | same as `rainy`        |
-| `partlycloudy`    | `#b3dbff`              |
-| `pouring`         | same as `rainy`        |
-| `rainy`           | `#44739d`              |
-| `snowy`           | `#fff`                 |
-| `snowy-rainy`     | same as `partlycloudy` |
-| `sunny`           | `#90cbff`              |
-| `windy`           | same as `sunny`        |
-| `windy-variant`   | same as `sunny`        |
-| `exceptional`     | `#ff9d00`              |
+| Key                   | Default                |
+|-----------------------|------------------------|
+| `clear-night`         | `#111`                 |
+| `cloudy`              | `#777`                 |
+| `fog`                 | same as `cloudy`       |
+| `hail`                | `#2b5174`              |
+| `lightning`           | same as `rainy`        |
+| `lightning-rainy`     | same as `rainy`        |
+| `partlycloudy`        | `#b3dbff`              |
+| `night-partly-cloudy` | `#333`                 |
+| `pouring`             | same as `rainy`        |
+| `rainy`               | `#44739d`              |
+| `snowy`               | `#fff`                 |
+| `snowy-rainy`         | same as `partlycloudy` |
+| `sunny`               | `#90cbff`              |
+| `windy`               | same as `sunny`        |
+| `windy-variant`       | same as `sunny`        |
+| `exceptional`         | `#ff9d00`              |
 
 ### Sample colors configuration
 
@@ -211,23 +232,24 @@ colors:
 `icon_map` can be used to customize the icon used for each weather condition. It is specified as an object containing
 one or more of the keys listed below and values that are valid icons installed in Home Assistant.
 
-| Key               | Default                       |
-|-------------------|-------------------------------|
-| `clear-night`     | `mdi:weather-night`           |
-| `cloudy`          | `mdi:weather-cloudy`          |
-| `fog`             | `mdi:weather-fog`             |
-| `hail`            | `mdi:weather-hail`            |
-| `lightning`       | `mdi:weather-lightning`       |
-| `lightning-rainy` | `mdi:weather-lightning-rainy` |
-| `partlycloudy`    | `mdi:weather-partly-cloudy`   |
-| `pouring`         | `mdi:weather-pouring`         |
-| `rainy`           | `mdi:weather-rainy`           |
-| `snowy`           | `mdi:weather-snowy`           |
-| `snowy-rainy`     | `mdi:weather-snowy-rainy`     |
-| `sunny`           | `mdi:weather-sunny`           |
-| `windy`           | `mdi:weather-windy`           |
-| `windy-variant`   | `mdi:weather-windy-variant`   |
-| `exceptional`     | `mdi:alert-outline`           |
+| Key                   | Default                           |
+|-----------------------|-----------------------------------|
+| `clear-night`         | `mdi:weather-night`               |
+| `cloudy`              | `mdi:weather-cloudy`              |
+| `fog`                 | `mdi:weather-fog`                 |
+| `hail`                | `mdi:weather-hail`                |
+| `lightning`           | `mdi:weather-lightning`           |
+| `lightning-rainy`     | `mdi:weather-lightning-rainy`     |
+| `partlycloudy`        | `mdi:weather-partly-cloudy`       |
+| `night-partly-cloudy` | `mdi:weather-night-partly-cloudy` |
+| `pouring`             | `mdi:weather-pouring`             |
+| `rainy`               | `mdi:weather-rainy`               |
+| `snowy`               | `mdi:weather-snowy`               |
+| `snowy-rainy`         | `mdi:weather-snowy-rainy`         |
+| `sunny`               | `mdi:weather-sunny`               |
+| `windy`               | `mdi:weather-windy`               |
+| `windy-variant`       | `mdi:weather-windy-variant`       |
+| `exceptional`         | `mdi:alert-outline`               |
 
 ### Sample icon map configuration
 

--- a/cypress/e2e/day-night.cy.ts
+++ b/cypress/e2e/day-night.cy.ts
@@ -1,0 +1,132 @@
+/**
+ * Day/night resolution of conditions.
+ *
+ * The harness forecast deliberately reports the same day/night flavour for
+ * every segment, the way Home Assistant weather integrations do: `sunny` for
+ * 2022-07-21T23:00Z through 2022-07-22T03:00Z and `clear-night` for
+ * 2022-07-22T04:00Z, regardless of where the sun actually is. The card is
+ * expected to resolve each segment against its own timestamp.
+ *
+ * Colombo, Sri Lanka is used as the home location. Over the twelve default
+ * segments no segment sits closer than 6.3 degrees to the horizon there, so
+ * the expected day/night split has plenty of margin and all three transitions
+ * occur: `partlycloudy` to night, `sunny` to night, and `clear-night` to day.
+ */
+const COLOMBO_LAT = 6.9271;
+const COLOMBO_LON = 79.8612;
+
+describe('Day/night conditions', () => {
+  beforeEach(() => {
+    cy.visitHarness();
+  });
+
+  describe('without a home location', () => {
+    it('renders the conditions exactly as reported', () => {
+      cy.get('weather-bar')
+        .shadow()
+        .find('div.bar > div')
+        .should('have.length', 4)
+        .each((el, i) => {
+          cy.wrap(el).invoke('attr', 'data-tippy-content')
+            .should('eq', ['Cloudy', 'Partly cloudy', 'Sunny', 'Clear'][i]);
+        });
+    });
+  });
+
+  describe('with a home location', () => {
+    beforeEach(() => {
+      cy.setHomeLocation(COLOMBO_LAT, COLOMBO_LON);
+      // A change to `hass.config` alone does not satisfy `shouldUpdate`, so
+      // re-apply the config to force a render. Home Assistant always has the
+      // home location in place before the card first renders.
+      cy.configure({});
+    });
+
+    const expectedLabels = [
+      'Cloudy',
+      'Partly cloudy (night)',
+      'Clear',
+      'Sunny'
+    ];
+    const expectedWidths = [6, 6, 4, 8];
+    const expectedColors = [
+      'rgb(119, 119, 119)',
+      'rgb(51, 51, 51)',
+      'rgb(17, 17, 17)',
+      'rgb(144, 203, 255)'
+    ];
+    const expectedIcons = [
+      'mdi:weather-cloudy',
+      'mdi:weather-night-partly-cloudy',
+      'mdi:weather-night',
+      'mdi:weather-sunny'
+    ];
+
+    it('resolves each segment against its own timestamp', () => {
+      cy.get('weather-bar')
+        .shadow()
+        .find('div.bar > div')
+        .should('have.length', 4)
+        .each((el, i) => {
+          cy.wrap(el).invoke('attr', 'data-tippy-content')
+            .should('eq', expectedLabels[i]);
+        });
+    });
+
+    it('has condition blocks of the correct width and color', () => {
+      cy.get('weather-bar')
+        .shadow()
+        .find('div.bar > div')
+        .each((el, i) => {
+          const cs = window.getComputedStyle(el.get(0));
+          const width = parseInt(cs.gridColumnEnd, 10) - parseInt(cs.gridColumnStart, 10);
+          expect(width).to.eq(expectedWidths[i]);
+          expect(cs.backgroundColor).to.eq(expectedColors[i]);
+        });
+    });
+
+    it('shows the nighttime icons', () => {
+      cy.configure({ icons: true });
+      cy.get('weather-bar')
+        .shadow()
+        .find('div.bar > div > span.condition-icon')
+        .should('have.length', 4)
+        .find('ha-icon')
+        .each((el, i) => {
+          cy.wrap(el).invoke('attr', 'icon')
+            .should('eq', expectedIcons[i]);
+        });
+    });
+
+    it('allows night-partly-cloudy to be recolored', () => {
+      cy.configure({
+        colors: {
+          'night-partly-cloudy': 'rgb(0, 255, 0)'
+        }
+      });
+      cy.get('weather-bar')
+        .shadow()
+        .find('div.bar > div')
+        .eq(1)
+        .should(el => {
+          expect(window.getComputedStyle(el.get(0)).backgroundColor).to.eq('rgb(0, 255, 0)');
+        });
+    });
+
+    it('allows the night-partly-cloudy icon to be overridden', () => {
+      cy.configure({
+        icons: true,
+        icon_map: {
+          'night-partly-cloudy': 'foo:bar'
+        }
+      });
+      cy.get('weather-bar')
+        .shadow()
+        .find('div.bar > div')
+        .its(1)
+        .find('span.condition-icon > ha-icon')
+        .invoke('attr', 'icon')
+        .should('eq', 'foo:bar');
+    });
+  });
+});

--- a/cypress/e2e/weather-bar.cy.ts
+++ b/cypress/e2e/weather-bar.cy.ts
@@ -1197,11 +1197,11 @@ describe('Weather bar', () => {
         .find('div.axes > div.bar-block div.precipitation')
         .should('have.length', 12)
         .each((el, i) => {
-            if (expectedPrecipitation[i] === 0) {
-              cy.wrap(el).should('be.empty');
-            } else {
-              cy.wrap(el).should('have.text', `${expectedPrecipitation[i]} in`);
-            }
+          if (expectedPrecipitation[i] === 0) {
+            cy.wrap(el).should('be.empty');
+          } else {
+            cy.wrap(el).should('have.text', `${expectedPrecipitation[i]} in`);
+          }
         });
     });
 
@@ -1216,10 +1216,10 @@ describe('Weather bar', () => {
         .should('have.length', 12)
         .each((el, i) => {
           if (i % 2 === 0) {
-            if (expectedPrecipitation[i] + expectedPrecipitation[i+1] === 0) {
+            if (expectedPrecipitation[i] + expectedPrecipitation[i + 1] === 0) {
               cy.wrap(el).should('be.empty');
             } else {
-              cy.wrap(el).should('have.text', `${expectedPrecipitation[i] + expectedPrecipitation[i+1]} in`);
+              cy.wrap(el).should('have.text', `${expectedPrecipitation[i] + expectedPrecipitation[i + 1]} in`);
             }
           }
           else {
@@ -1283,18 +1283,18 @@ describe('Weather bar', () => {
           else {
             const firstProbability = expectedPrecipitationProbability[i];
             const secondProbability = expectedPrecipitationProbability[i + 1];
-            const expectedExpectedProbability = i < 4 ? aggregateProbability(firstProbability, secondProbability): firstProbability;
+            const expectedExpectedProbability = i < 4 ? aggregateProbability(firstProbability, secondProbability) : firstProbability;
             if (expectedExpectedProbability === 0) {
               cy.wrap(el.text()).should('be.empty');
             } else {
               cy.wrap(el).should(
-                'have.text', 
+                'have.text',
                 `${expectedExpectedProbability}%`
               )
                 .find('span')
                 .should(
-                  'have.attr', 
-                  'title', 
+                  'have.attr',
+                  'title',
                   `${expectedExpectedProbability}% chance of precipitation`
                 );
             }

--- a/cypress/fixtures/harness.html
+++ b/cypress/fixtures/harness.html
@@ -611,6 +611,14 @@
           }
         }
       };
+      window.setHWHomeLocation = (latitude, longitude) => h.hass = {
+        ...h.hass,
+        config: {
+          ...h.hass.config,
+          latitude,
+          longitude
+        }
+      };
       window.setHWLocale = locale => h.hass = {
         ...h.hass,
         locale: {

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -70,6 +70,10 @@ interface HALocale {
   time_format: string;
 }
 
+Cypress.Commands.add('setHomeLocation', (latitude: number, longitude: number) => {
+  cy.window().invoke('setHWHomeLocation', latitude, longitude).wait(1);
+});
+
 Cypress.Commands.add('setLocale', (locale: Partial<HALocale>) => {
   cy.window().invoke('setHWLocale', locale).wait(1);
 });
@@ -99,6 +103,7 @@ declare global {
       addForecast(entityId: string, forecast: ForecastSegment[]): Chainable<void>;
       enableForecastSubscriptions(): Chainable<void>;
       updateLastForecastSubscription(forecast: ForecastSegment[]): Chainable<void>;
+      setHomeLocation(latitude: number, longitude: number): Chainable<void>;
       setLocale(locale: Partial<HALocale>): Chainable<void>;
       slotAssignedNodes(name?: string): Chainable<Node[]>;
     }

--- a/src/conditions.ts
+++ b/src/conditions.ts
@@ -1,4 +1,6 @@
-export const LABELS = {
+import type { DayNightVariants, DisplayCondition } from './types';
+
+export const LABELS: Record<DisplayCondition, string> = {
   'clear-night': 'conditions.clear',
   'cloudy': 'conditions.cloudy',
   'fog': 'conditions.fog',
@@ -6,6 +8,7 @@ export const LABELS = {
   'lightning': 'conditions.thunderstorm',
   'lightning-rainy': 'conditions.thunderstorm',
   'partlycloudy': 'conditions.partlyCloudy',
+  'night-partly-cloudy': 'conditions.partlyCloudyNight',
   'pouring': 'conditions.heavyRain',
   'rainy': 'conditions.rain',
   'snowy': 'conditions.snow',
@@ -15,7 +18,7 @@ export const LABELS = {
   'windy-variant': 'conditions.windy',
   'exceptional': 'conditions.clear'
 };
-export const ICONS = {
+export const ICONS: Record<DisplayCondition, string> = {
   'clear-night': 'weather-night',
   'cloudy': 'cloudy',
   'fog': 'fog',
@@ -23,6 +26,7 @@ export const ICONS = {
   'lightning': 'lightning',
   'lightning-rainy': 'lightning-rainy',
   'partlycloudy': 'weather-partly-cloudy',
+  'night-partly-cloudy': 'weather-night-partly-cloudy',
   'pouring': 'pouring',
   'rainy': 'rainy',
   'snowy': 'snowy',
@@ -31,4 +35,21 @@ export const ICONS = {
   'windy': 'windy',
   'windy-variant': 'windy-variant',
   'exceptional': 'alert-outline'
+};
+
+/**
+ * Conditions that Home Assistant reports without regard for whether the
+ * forecast segment falls during the day or during the night, mapped to the
+ * daytime and nighttime variant the card should render instead.
+ *
+ * Weather integrations derive `sunny` vs `clear-night` (and, where they support
+ * it at all, partly cloudy) from the sun position *at the time the forecast is
+ * produced*, so every segment of an hourly forecast gets the same day/night
+ * flavour. Resolving each segment against its own timestamp fixes that.
+ */
+export const DAY_NIGHT_VARIANTS: Partial<Record<DisplayCondition, DayNightVariants>> = {
+  'sunny': ['sunny', 'clear-night'],
+  'clear-night': ['sunny', 'clear-night'],
+  'partlycloudy': ['partlycloudy', 'night-partly-cloudy'],
+  'night-partly-cloudy': ['partlycloudy', 'night-partly-cloudy']
 };

--- a/src/hourly-weather.ts
+++ b/src/hourly-weather.ts
@@ -19,17 +19,18 @@ import { until } from 'lit/directives/until.js';
 
 import { version } from '../package.json';
 import { actionHandler } from './action-handler-directive';
-import { ICONS, LABELS } from './conditions';
+import { DAY_NIGHT_VARIANTS, ICONS, LABELS } from './conditions';
 import { DIRECTIONS } from './directions';
 import { getLocalizer } from './localize/localize';
+import { isDaytime } from './solar';
 import type {
   ColorConfig,
   ColorDefinition,
   ColorMap,
   ColorObject,
   ColorSettings,
-  Condition,
   ConditionSpan,
+  DisplayCondition,
   ForecastEvent,
   ForecastSegment,
   ForecastType,
@@ -425,11 +426,11 @@ export class HourlyWeatherCard extends LitElement {
   }
 
   private getConditionListFromForecast(forecast: ForecastSegment[], numSegments: number, offset: number): ConditionSpan[] {
-    let lastCond: Condition = forecast[offset].condition;
+    let lastCond: DisplayCondition = this.getDisplayCondition(forecast[offset]);
     let j = 0;
     const res: ConditionSpan[] = [[lastCond, 1]];
     for (let i = offset + 1; i < numSegments + offset; i++) {
-      const cond: Condition = forecast[i].condition;
+      const cond: DisplayCondition = this.getDisplayCondition(forecast[i]);
       if (cond === lastCond) {
         res[j][1]++;
       } else {
@@ -439,6 +440,35 @@ export class HourlyWeatherCard extends LitElement {
       }
     }
     return res;
+  }
+
+  /**
+   * Resolves the condition to render for a forecast segment, picking the
+   * daytime or nighttime variant based on whether the sun is up *at that
+   * segment's own timestamp*.
+   *
+   * Weather integrations pick `sunny` vs `clear-night` once, from the sun
+   * position at the time the forecast is generated, and apply it to every
+   * segment. So a forecast fetched at noon labels tonight's clear hours
+   * `sunny`, and one fetched at midnight labels tomorrow's clear hours
+   * `clear-night`. Resolving per segment fixes both directions.
+   *
+   * Falls back to the reported condition when the home location is unknown, so
+   * behaviour is unchanged for anyone whose `hass.config` carries no
+   * coordinates.
+   */
+  private getDisplayCondition(segment: ForecastSegment): DisplayCondition {
+    const variants = DAY_NIGHT_VARIANTS[segment.condition];
+    if (!variants) return segment.condition;
+
+    const { latitude, longitude } = this.hass?.config ?? {};
+    if (typeof latitude !== 'number' || typeof longitude !== 'number') return segment.condition;
+
+    const when = new Date(segment.datetime);
+    if (Number.isNaN(when.getTime())) return segment.condition;
+
+    const [day, night] = variants;
+    return isDaytime(when, latitude, longitude) ? day : night;
   }
 
   private getTemperatures(forecast: ForecastSegment[], numSegments: number, offset: number, hideMinutes: boolean, roundTemperatures: boolean): SegmentTemperature[] {

--- a/src/localize/languages/bg.json
+++ b/src/localize/languages/bg.json
@@ -46,6 +46,7 @@
     "hail": "Градушка",
     "thunderstorm": "Гръмотевична буря",
     "partlyCloudy": "Частична облачност",
+    "partlyCloudyNight": "Частична облачност (нощ)",
     "heavyRain": "Проливен дъжд",
     "rain": "Дъжд",
     "snow": "Сняг",

--- a/src/localize/languages/cs.json
+++ b/src/localize/languages/cs.json
@@ -46,6 +46,7 @@
     "hail": "Kroupy",
     "thunderstorm": "Bouřka",
     "partlyCloudy": "Polojasno",
+    "partlyCloudyNight": "Polojasno (noc)",
     "heavyRain": "Silný déšť",
     "rain": "Déšť",
     "snow": "Sníh",

--- a/src/localize/languages/da.json
+++ b/src/localize/languages/da.json
@@ -46,6 +46,7 @@
     "hail": "Hagl",
     "thunderstorm": "Torden",
     "partlyCloudy": "Delvist overskyet",
+    "partlyCloudyNight": "Delvist overskyet (nat)",
     "heavyRain": "Kraftig regn",
     "rain": "Regn",
     "snow": "Sne",

--- a/src/localize/languages/de.json
+++ b/src/localize/languages/de.json
@@ -46,6 +46,7 @@
     "hail": "Hagel",
     "thunderstorm": "Gewitter",
     "partlyCloudy": "Teilweise bewölkt",
+    "partlyCloudyNight": "Teilweise bewölkt (Nacht)",
     "heavyRain": "Platzregen",
     "rain": "Regen",
     "snow": "Schnee",

--- a/src/localize/languages/en.json
+++ b/src/localize/languages/en.json
@@ -46,6 +46,7 @@
     "hail": "Hail",
     "thunderstorm": "Thunderstorm",
     "partlyCloudy": "Partly cloudy",
+    "partlyCloudyNight": "Partly cloudy (night)",
     "heavyRain": "Heavy rain",
     "rain": "Rain",
     "snow": "Snow",

--- a/src/localize/languages/es.json
+++ b/src/localize/languages/es.json
@@ -46,6 +46,7 @@
     "hail": "Granizo",
     "thunderstorm": "Tormenta electrica",
     "partlyCloudy": "Parcialmente nublado",
+    "partlyCloudyNight": "Parcialmente nublado (noche)",
     "heavyRain": "Tormenta",
     "rain": "Lluvia",
     "snow": "Nieve",

--- a/src/localize/languages/fr.json
+++ b/src/localize/languages/fr.json
@@ -46,6 +46,7 @@
     "hail": "Grêle",
     "thunderstorm": "Orage",
     "partlyCloudy": "Éclaircies",
+    "partlyCloudyNight": "Éclaircies (nuit)",
     "heavyRain": "Averses",
     "rain": "Pluie",
     "snow": "Neige",

--- a/src/localize/languages/hu.json
+++ b/src/localize/languages/hu.json
@@ -46,6 +46,7 @@
     "hail": "Jégeső",
     "thunderstorm": "Vihar",
     "partlyCloudy": "Részben felhős",
+    "partlyCloudyNight": "Részben felhős (éjszaka)",
     "heavyRain": "Heves eső",
     "rain": "Esős",
     "snow": "Havazás",

--- a/src/localize/languages/it.json
+++ b/src/localize/languages/it.json
@@ -46,6 +46,7 @@
     "hail": "Grandine",
     "thunderstorm": "Temporale",
     "partlyCloudy": "Parzialmente Nuvoloso",
+    "partlyCloudyNight": "Parzialmente Nuvoloso (notte)",
     "heavyRain": "Acquazzone",
     "rain": "Pioggia",
     "snow": "Neve",

--- a/src/localize/languages/nb.json
+++ b/src/localize/languages/nb.json
@@ -46,6 +46,7 @@
     "hail": "Hagl",
     "thunderstorm": "Tordenvær",
     "partlyCloudy": "Delvis skyet",
+    "partlyCloudyNight": "Delvis skyet (natt)",
     "heavyRain": "Mye regn",
     "rain": "Regn",
     "snow": "Snø",

--- a/src/localize/languages/nl.json
+++ b/src/localize/languages/nl.json
@@ -46,6 +46,7 @@
     "hail": "Hagel",
     "thunderstorm": "Onweersbui",
     "partlyCloudy": "Half bewolkt",
+    "partlyCloudyNight": "Half bewolkt (nacht)",
     "heavyRain": "Zware regen",
     "rain": "Regen",
     "snow": "Sneeuw",

--- a/src/localize/languages/nn-NO.json
+++ b/src/localize/languages/nn-NO.json
@@ -48,6 +48,7 @@
     "hail": "Hagl",
     "thunderstorm": "Tordenvær",
     "partlyCloudy": "Delvis skya",
+    "partlyCloudyNight": "Delvis skya (natt)",
     "heavyRain": "Mykje regn",
     "rain": "Regn",
     "snow": "Snø",

--- a/src/localize/languages/pl.json
+++ b/src/localize/languages/pl.json
@@ -46,6 +46,7 @@
     "hail": "Grad",
     "thunderstorm": "Burza",
     "partlyCloudy": "Częściowe zachmurzenie",
+    "partlyCloudyNight": "Częściowe zachmurzenie (noc)",
     "heavyRain": "Ulewa",
     "rain": "Deszcz",
     "snow": "Śnieg",

--- a/src/localize/languages/pt-BR.json
+++ b/src/localize/languages/pt-BR.json
@@ -48,6 +48,7 @@
     "hail": "Granizo",
     "thunderstorm": "Tempestade",
     "partlyCloudy": "Parcialmente nublado",
+    "partlyCloudyNight": "Parcialmente nublado (noite)",
     "heavyRain": "Chuva pesada",
     "rain": "Chuva",
     "snow": "Neve",

--- a/src/localize/languages/pt.json
+++ b/src/localize/languages/pt.json
@@ -46,6 +46,7 @@
     "hail": "Granizo",
     "thunderstorm": "Trovoada",
     "partlyCloudy": "Pouco nublado",
+    "partlyCloudyNight": "Pouco nublado (noite)",
     "heavyRain": "Chuva forte",
     "rain": "Chuva",
     "snow": "Neve",

--- a/src/localize/languages/ru.json
+++ b/src/localize/languages/ru.json
@@ -46,6 +46,7 @@
     "hail": "Град",
     "thunderstorm": "Гроза",
     "partlyCloudy": "Частичная облачность",
+    "partlyCloudyNight": "Частичная облачность (ночь)",
     "heavyRain": "Сильный дождь",
     "rain": "Дождь",
     "snow": "Снег",

--- a/src/localize/languages/sk.json
+++ b/src/localize/languages/sk.json
@@ -46,6 +46,7 @@
     "hail": "Ľadovec",
     "thunderstorm": "Búrka",
     "partlyCloudy": "Čiastočne zamračené",
+    "partlyCloudyNight": "Čiastočne zamračené (noc)",
     "heavyRain": "Hustý dážď",
     "rain": "Dážď",
     "snow": "Sneh",

--- a/src/localize/languages/tr.json
+++ b/src/localize/languages/tr.json
@@ -46,6 +46,7 @@
     "hail": "Dolu",
     "thunderstorm": "Gök gürültülü fırtına",
     "partlyCloudy": "Parçalı bulutlu",
+    "partlyCloudyNight": "Parçalı bulutlu (gece)",
     "heavyRain": "Şiddetli yağmur",
     "rain": "Yağmur",
     "snow": "Kar",

--- a/src/localize/languages/uk.json
+++ b/src/localize/languages/uk.json
@@ -46,6 +46,7 @@
     "hail": "Град",
     "thunderstorm": "Гроза",
     "partlyCloudy": "Частково хмарно",
+    "partlyCloudyNight": "Частково хмарно (ніч)",
     "heavyRain": "Сильний дощ",
     "rain": "Дощ",
     "snow": "Сніг",

--- a/src/localize/languages/zh.json
+++ b/src/localize/languages/zh.json
@@ -46,6 +46,7 @@
     "hail": "冰雹",
     "thunderstorm": "雷暴",
     "partlyCloudy": "局部多云",
+    "partlyCloudyNight": "局部多云（夜间）",
     "heavyRain": "大雨",
     "rain": "雨",
     "snow": "雪",

--- a/src/solar.ts
+++ b/src/solar.ts
@@ -2,7 +2,14 @@
  * Solar position math, used to decide whether a forecast segment falls during
  * the day or during the night.
  *
- * Everything here works purely on the epoch milliseconds of a `Date`. There is
+ * This is the standard low-precision solar position approximation: derive the
+ * sun's ecliptic longitude from its mean longitude plus a two-term equation of
+ * center, rotate into equatorial coordinates using the obliquity of the
+ * ecliptic, then combine with sidereal time and the observer's latitude to get
+ * an elevation. It is good to a fraction of a degree, and only the sign of the
+ * result matters here.
+ *
+ * Everything works purely on the epoch milliseconds of a `Date`. There is
  * deliberately no local-date arithmetic and no locale-formatted date string
  * involved: a previous implementation derived a reference day via
  * `new Date(when.toLocaleDateString())`, which produces `Invalid Date` in every
@@ -12,13 +19,55 @@
  * every segment was treated as night. See #692.
  */
 
-const DEG = Math.PI / 180;
+// --- Unit conversions -------------------------------------------------------
 
-/** Julian day number of the J2000.0 epoch. */
-const J2000 = 2451545;
-
-/** Milliseconds in a day. */
+const DEG_TO_RAD = Math.PI / 180;
+const DEGREES_PER_TURN = 360;
+const HOURS_PER_TURN = 24;
 const MS_PER_DAY = 86400000;
+
+/** Degrees the earth turns per hour: 360 / 24. */
+const DEGREES_PER_HOUR = 15;
+
+// --- Epochs -----------------------------------------------------------------
+
+/** Julian day number of J2000.0, the epoch every term below is relative to. */
+const JULIAN_DAY_J2000 = 2451545;
+
+/** Julian day number of the Unix epoch, 1970-01-01T00:00:00Z. */
+const JULIAN_DAY_UNIX_EPOCH = 2440587.5;
+
+// --- Sun's mean longitude, in degrees ---------------------------------------
+
+const MEAN_LONGITUDE_AT_J2000 = 280.46;
+const MEAN_LONGITUDE_PER_DAY = 0.9856474;
+
+// --- Sun's mean anomaly, in degrees -----------------------------------------
+
+const MEAN_ANOMALY_AT_J2000 = 357.528;
+const MEAN_ANOMALY_PER_DAY = 0.9856003;
+
+// --- Equation of center, in degrees -----------------------------------------
+// Corrects the mean longitude for the eccentricity of earth's orbit. Two terms
+// are plenty at this precision.
+
+const EQUATION_OF_CENTER_1ST_ORDER = 1.915;
+const EQUATION_OF_CENTER_2ND_ORDER = 0.02;
+
+// --- Obliquity of the ecliptic, in degrees ----------------------------------
+// The tilt of earth's axis, which is slowly decreasing.
+
+const OBLIQUITY_AT_J2000 = 23.439;
+const OBLIQUITY_DECREASE_PER_DAY = 0.0000004;
+
+// --- Greenwich mean sidereal time, in hours ---------------------------------
+// A sidereal day is slightly shorter than a solar day, hence the value just
+// over 24 hours per day.
+
+const GMST_AT_J2000_HOURS = 18.697374558;
+const GMST_PER_DAY_HOURS = 24.06570982441908;
+
+// --- Horizon ----------------------------------------------------------------
 
 /**
  * Apparent elevation of the sun's upper limb at sunrise/sunset, in degrees.
@@ -29,8 +78,7 @@ export const HORIZON_ELEVATION = -0.833;
 
 /**
  * Elevation of the sun above the horizon, in degrees, for a point in time and
- * a position on earth. Accurate to a few hundredths of a degree, which is far
- * more than enough to tell day from night.
+ * a position on earth.
  *
  * @param when Point in time to evaluate.
  * @param latitude Degrees north of the equator.
@@ -39,31 +87,38 @@ export const HORIZON_ELEVATION = -0.833;
 export function solarElevation(when: Date, latitude: number, longitude: number): number {
   // Days since J2000.0, derived from epoch millis so no timezone or locale
   // handling can creep in.
-  const d = when.getTime() / MS_PER_DAY + 2440587.5 - J2000;
+  const daysSinceJ2000 = when.getTime() / MS_PER_DAY
+    + JULIAN_DAY_UNIX_EPOCH - JULIAN_DAY_J2000;
 
-  // Sun's position in ecliptic coordinates.
-  const meanLongitude = (280.46 + 0.9856474 * d) % 360;
-  const meanAnomaly = ((357.528 + 0.9856003 * d) % 360) * DEG;
+  // Where the sun is along the ecliptic.
+  const meanLongitude = (MEAN_LONGITUDE_AT_J2000
+    + MEAN_LONGITUDE_PER_DAY * daysSinceJ2000) % DEGREES_PER_TURN;
+  const meanAnomaly = ((MEAN_ANOMALY_AT_J2000
+    + MEAN_ANOMALY_PER_DAY * daysSinceJ2000) % DEGREES_PER_TURN) * DEG_TO_RAD;
   const eclipticLongitude = (meanLongitude
-    + 1.915 * Math.sin(meanAnomaly)
-    + 0.02 * Math.sin(2 * meanAnomaly)) * DEG;
-  const obliquity = (23.439 - 0.0000004 * d) * DEG;
+    + EQUATION_OF_CENTER_1ST_ORDER * Math.sin(meanAnomaly)
+    + EQUATION_OF_CENTER_2ND_ORDER * Math.sin(2 * meanAnomaly)) * DEG_TO_RAD;
 
-  // ...converted to equatorial coordinates.
+  // Rotate from ecliptic into equatorial coordinates.
+  const obliquity = (OBLIQUITY_AT_J2000
+    - OBLIQUITY_DECREASE_PER_DAY * daysSinceJ2000) * DEG_TO_RAD;
   const declination = Math.asin(Math.sin(obliquity) * Math.sin(eclipticLongitude));
   const rightAscension = Math.atan2(
     Math.cos(obliquity) * Math.sin(eclipticLongitude),
     Math.cos(eclipticLongitude));
 
-  // Greenwich mean sidereal time, in hours, then the local hour angle.
-  let gmst = (18.697374558 + 24.06570982441908 * d) % 24;
-  if (gmst < 0) gmst += 24;
-  const hourAngle = gmst * 15 * DEG + longitude * DEG - rightAscension;
+  // How far the observer's meridian has turned past the sun.
+  let gmstHours = (GMST_AT_J2000_HOURS
+    + GMST_PER_DAY_HOURS * daysSinceJ2000) % HOURS_PER_TURN;
+  if (gmstHours < 0) gmstHours += HOURS_PER_TURN;
+  const hourAngle = gmstHours * DEGREES_PER_HOUR * DEG_TO_RAD
+    + longitude * DEG_TO_RAD
+    - rightAscension;
 
-  const lat = latitude * DEG;
+  const observerLatitude = latitude * DEG_TO_RAD;
   return Math.asin(
-    Math.sin(lat) * Math.sin(declination)
-    + Math.cos(lat) * Math.cos(declination) * Math.cos(hourAngle)) / DEG;
+    Math.sin(observerLatitude) * Math.sin(declination)
+    + Math.cos(observerLatitude) * Math.cos(declination) * Math.cos(hourAngle)) / DEG_TO_RAD;
 }
 
 /**

--- a/src/solar.ts
+++ b/src/solar.ts
@@ -116,9 +116,16 @@ export function solarElevation(when: Date, latitude: number, longitude: number):
     - rightAscension;
 
   const observerLatitude = latitude * DEG_TO_RAD;
-  return Math.asin(
-    Math.sin(observerLatitude) * Math.sin(declination)
-    + Math.cos(observerLatitude) * Math.cos(declination) * Math.cos(hourAngle)) / DEG_TO_RAD;
+
+  // Mathematically the cosine of the zenith angle, so within [-1, 1]. Rounding
+  // can carry it one ULP past 1 when the sun is almost exactly overhead, which
+  // would turn the `asin` into `NaN`, so clamp before taking it. Reaching that
+  // needs the latitude to equal the sun's declination, which confines it to the
+  // tropics; at high latitudes the value stays well below 1.
+  const sinElevation = Math.sin(observerLatitude) * Math.sin(declination)
+    + Math.cos(observerLatitude) * Math.cos(declination) * Math.cos(hourAngle);
+
+  return Math.asin(Math.min(1, Math.max(-1, sinElevation))) / DEG_TO_RAD;
 }
 
 /**

--- a/src/solar.ts
+++ b/src/solar.ts
@@ -1,0 +1,74 @@
+/**
+ * Solar position math, used to decide whether a forecast segment falls during
+ * the day or during the night.
+ *
+ * Everything here works purely on the epoch milliseconds of a `Date`. There is
+ * deliberately no local-date arithmetic and no locale-formatted date string
+ * involved: a previous implementation derived a reference day via
+ * `new Date(when.toLocaleDateString())`, which produces `Invalid Date` in every
+ * locale whose short date format `Date`'s parser does not understand (`de-DE`
+ * `13.6.2024`, `en-GB` `13/06/2024`, `nl-NL` `13-6-2024`, ...). Sunrise/sunset
+ * then came out as `NaN`, every comparison against them was `false`, and so
+ * every segment was treated as night. See #692.
+ */
+
+const DEG = Math.PI / 180;
+
+/** Julian day number of the J2000.0 epoch. */
+const J2000 = 2451545;
+
+/** Milliseconds in a day. */
+const MS_PER_DAY = 86400000;
+
+/**
+ * Apparent elevation of the sun's upper limb at sunrise/sunset, in degrees.
+ * Home Assistant's `sun.sun` uses the same value to flip between
+ * `above_horizon` and `below_horizon`, so the card agrees with it.
+ */
+export const HORIZON_ELEVATION = -0.833;
+
+/**
+ * Elevation of the sun above the horizon, in degrees, for a point in time and
+ * a position on earth. Accurate to a few hundredths of a degree, which is far
+ * more than enough to tell day from night.
+ *
+ * @param when Point in time to evaluate.
+ * @param latitude Degrees north of the equator.
+ * @param longitude Degrees east of Greenwich.
+ */
+export function solarElevation(when: Date, latitude: number, longitude: number): number {
+  // Days since J2000.0, derived from epoch millis so no timezone or locale
+  // handling can creep in.
+  const d = when.getTime() / MS_PER_DAY + 2440587.5 - J2000;
+
+  // Sun's position in ecliptic coordinates.
+  const meanLongitude = (280.46 + 0.9856474 * d) % 360;
+  const meanAnomaly = ((357.528 + 0.9856003 * d) % 360) * DEG;
+  const eclipticLongitude = (meanLongitude
+    + 1.915 * Math.sin(meanAnomaly)
+    + 0.02 * Math.sin(2 * meanAnomaly)) * DEG;
+  const obliquity = (23.439 - 0.0000004 * d) * DEG;
+
+  // ...converted to equatorial coordinates.
+  const declination = Math.asin(Math.sin(obliquity) * Math.sin(eclipticLongitude));
+  const rightAscension = Math.atan2(
+    Math.cos(obliquity) * Math.sin(eclipticLongitude),
+    Math.cos(eclipticLongitude));
+
+  // Greenwich mean sidereal time, in hours, then the local hour angle.
+  let gmst = (18.697374558 + 24.06570982441908 * d) % 24;
+  if (gmst < 0) gmst += 24;
+  const hourAngle = gmst * 15 * DEG + longitude * DEG - rightAscension;
+
+  const lat = latitude * DEG;
+  return Math.asin(
+    Math.sin(lat) * Math.sin(declination)
+    + Math.cos(lat) * Math.cos(declination) * Math.cos(hourAngle)) / DEG;
+}
+
+/**
+ * Whether the sun is above the horizon at the given time and place.
+ */
+export function isDaytime(when: Date, latitude: number, longitude: number): boolean {
+  return solarElevation(when, latitude, longitude) > HORIZON_ELEVATION;
+}

--- a/src/solar.ts
+++ b/src/solar.ts
@@ -11,12 +11,7 @@
  *
  * Everything works purely on the epoch milliseconds of a `Date`. There is
  * deliberately no local-date arithmetic and no locale-formatted date string
- * involved: a previous implementation derived a reference day via
- * `new Date(when.toLocaleDateString())`, which produces `Invalid Date` in every
- * locale whose short date format `Date`'s parser does not understand (`de-DE`
- * `13.6.2024`, `en-GB` `13/06/2024`, `nl-NL` `13-6-2024`, ...). Sunrise/sunset
- * then came out as `NaN`, every comparison against them was `false`, and so
- * every segment was treated as night. See #692.
+ * involved.
  */
 
 // --- Unit conversions -------------------------------------------------------

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,7 +11,15 @@ export type WindType = 'true' | 'false' | 'speed' | 'direction' | 'barb' | 'barb
 export type ShowDateType = 'false' | 'boundary' | 'all';
 export type IconFillType = 'single' | 'full' | number;
 export type Condition = 'clear-night' | 'cloudy' | 'fog' | 'hail' | 'lightning' | 'lightning-rainy' | 'partlycloudy' | 'pouring' | 'rainy' | 'snowy' | 'snowy-rainy' | 'sunny' | 'windy' | 'windy-variant' | 'exceptional';
-type PerConditionConfig<TValue> = Partial<Record<Condition, TValue>>;
+/**
+ * Conditions the card can render. A superset of the conditions Home Assistant
+ * reports: `night-partly-cloudy` is derived by the card for partly cloudy
+ * segments that fall after sunset.
+ */
+export type DisplayCondition = Condition | 'night-partly-cloudy';
+/** Daytime and nighttime variant of a condition, in that order. */
+export type DayNightVariants = [day: DisplayCondition, night: DisplayCondition];
+type PerConditionConfig<TValue> = Partial<Record<DisplayCondition, TValue>>;
 export type IconMap = PerConditionConfig<string>;
 
 export interface HourlyWeatherCardConfig extends LovelaceCardConfig {
@@ -66,7 +74,7 @@ export interface ForecastSegment {
 }
 
 export type ConditionSpan = [
-  condition: Condition,
+  condition: DisplayCondition,
   span: number
 ]
 

--- a/src/weather-bar.ts
+++ b/src/weather-bar.ts
@@ -227,6 +227,7 @@ export class WeatherBar extends LitElement {
       --color-lightning: var(--color-rainy);
       --color-lightning-rainy: var(--color-rainy);
       --color-partlycloudy: #b3dbff;
+      --color-night-partly-cloudy: #333;
       --color-pouring: var(--color-rainy);
       --color-rainy: #44739d;
       --color-snowy: white;
@@ -298,6 +299,10 @@ export class WeatherBar extends LitElement {
     .partlycloudy {
       background-color: var(--color-partlycloudy);
       color: var(--color-partlycloudy-foreground, var(--primary-text-color));
+    }
+    .night-partly-cloudy {
+      background-color: var(--color-night-partly-cloudy);
+      color: var(--color-night-partly-cloudy-foreground, var(--primary-text-color));
     }
     .pouring {
       background-color: var(--color-pouring);


### PR DESCRIPTION
Weather integrations pick `sunny` vs `clear-night` once, from the sun position at the time the forecast is generated, and apply that one choice to every segment. A forecast fetched at noon therefore labels tonight's clear hours `sunny`, and one fetched after dark labels tomorrow's clear hours `clear-night`.

Resolve each segment against its own timestamp instead, using the home location from `hass.config`. This also re-lands the `night-partly-cloudy` condition from #689, which was disabled in #698.

The bug that caused that revert was in how the reference day was derived:

    const noonUTCOnDay = new Date(when.toLocaleDateString());

`toLocaleDateString()` without arguments returns the browser's short date format, and `Date`'s parser only understands a few of those. `de-DE` (`13.6.2024`), `en-GB` (`13/06/2024`), `it-IT`, `nl-NL` and `pl-PL` all yield `Invalid Date`, so sunrise and sunset came out `NaN`, both comparisons against them were `false`, and every segment was treated as night — the whole-day night icon reported in #692. It read as a timezone problem, but it was the locale.

`solarElevation()` avoids that class of bug entirely: it works from epoch milliseconds, computes the sun's elevation directly, and needs neither a locale-formatted string, nor day-boundary arithmetic, nor the `solar-calculator` dependency. Day and night are separated at -0.833 degrees, the same threshold Home Assistant's `sun.sun` uses.

When `hass.config` carries no coordinates, the reported condition is used unchanged, so behaviour for those setups is untouched.

Fixes #959
Fixes #662

<img width="1027" height="158" alt="Screenshot 2026-08-23 at 07 31 51" src="https://github.com/user-attachments/assets/0a1b6a71-84ff-463e-89eb-a70e692088c1" />
