### PR TITLE
feat: add option to show expected precipitation (forcast amount x probability)

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ decimal by 1). Otherwise, the integration may complain of a duplicate unique ID.
 | `hide_bar`                       | bool                   | **Optional** | Whether to hide the bar itself                                                                                                                                  | `false`             |
 | `icon_fill`                      | [Icon Fill][icon_fill] | **Optional** | Whether to repeat the icon inside the bar                                                                                                                       | `'single`           |
 | `show_wind`                      | [Wind][wind]           | **Optional** | Whether to show wind speed and/or direction under the bar                                                                                                       | `'false'`           |
+| `show_expected_precipitation`    | bool                   | **Optional** | Whether to show the aggregated expected precipitation (rain) amount (calculated as $amount * probability$) for each displayed label interval under the bar (disables `show_precipitation_amounts` and `show_precipitations_probability`)                                                                    | `false`             |
 | `show_precipitation_amounts`     | bool                   | **Optional** | Whether to show the aggregated precipitation (rain) amount for each displayed label interval under the bar                                                                                                       | `false`             |
 | `show_precipitation_probability` | bool                   | **Optional** | Whether to show the combined precipitation probability for each displayed label interval under the bar                                                                                                  | `false`             |
 | `show_date`                      | [string][dates]        | **Optional** | Whether to show date under the bar                                                                                                                              | `'false'`           |
@@ -93,12 +94,12 @@ decimal by 1). Otherwise, the integration may complain of a duplicate unique ID.
 
 ### Precipitation and label spacing
 
-When precipitation amounts or probabilities are enabled, their values represent
+When expected precipitation, precipitation amounts or probabilities are enabled, their values represent
 the forecast segments covered by each displayed label.
 
 For example, with `label_spacing: 2`, the precipitation label at the first
 segment summarizes segments 1-2, the next label summarizes segments 3-4, and
-so on. Precipitation amounts are summed. Precipitation probabilities are combined as the probability that precipitation
+so on. Precipitation amounts and expected precipitation amounts are summed. Precipitation probabilities are combined as the probability that precipitation
 occurs during at least one segment in that interval:
 
 $$

--- a/cypress/e2e/editor.cy.ts
+++ b/cypress/e2e/editor.cy.ts
@@ -1,0 +1,101 @@
+export {};
+
+type TestEditor = HTMLElement & {
+  shadowRoot: ShadowRoot;
+};
+
+declare global {
+  interface Window {
+    testEditor: TestEditor;
+  }
+}
+
+describe('Editor', () => {
+  beforeEach(() => {
+    cy.visit('editor-harness.html');
+    cy.window().should('have.property', 'editorReady', true);
+  });
+
+  function getHaForm() {
+    return cy.window()
+        .its('testEditor')
+        .should('exist')
+        .then(editor => {
+        const testEditor = editor as unknown as TestEditor;
+        const form = testEditor.shadowRoot.querySelector('ha-form');
+
+        expect(form).to.exist;
+
+        return cy.wrap(form);
+        });
+  }
+
+  function input(name: string) {
+    return getHaForm().find(`input[data-name="${name}"]`);
+  }
+
+  it('does not disable precipitation switches by default', () => {
+    input('show_expected_precipitation')
+      .should('not.be.disabled');
+
+    input('show_precipitation_amounts')
+      .should('not.be.disabled');
+
+    input('show_precipitation_probability')
+      .should('not.be.disabled');
+  });
+
+  it('disables both precipitation switches when expected precipitation is enabled', () => {
+    input('show_expected_precipitation')
+      .check();
+
+    input('show_precipitation_amounts')
+      .should('be.disabled');
+
+    input('show_precipitation_probability')
+      .should('be.disabled');
+  });
+
+  it('re-enables both precipitation switches when expected precipitation is disabled', () => {
+    input('show_expected_precipitation')
+      .check();
+
+    input('show_precipitation_amounts')
+      .should('be.disabled');
+
+    input('show_precipitation_probability')
+      .should('be.disabled');
+
+    input('show_expected_precipitation')
+      .uncheck();
+
+    input('show_precipitation_amounts')
+      .should('not.be.disabled');
+
+    input('show_precipitation_probability')
+      .should('not.be.disabled');
+  });
+
+  it('disables both switches when expected precipitation is initially enabled', () => {
+    cy.get('hourly-weather-editor')
+      .then(async ($editor) => {
+        const editor = $editor[0] as HTMLElement & {
+          setConfig(config: Record<string, unknown>): Promise<void>;
+        };
+
+        await editor.setConfig({
+          type: 'custom:hourly-weather',
+          entity: 'weather.mock',
+          show_expected_precipitation: true,
+          show_precipitation_amounts: false,
+          show_precipitation_probability: false,
+        });
+      });
+
+    input('show_precipitation_amounts')
+      .should('be.disabled');
+
+    input('show_precipitation_probability')
+      .should('be.disabled');
+  });
+});

--- a/cypress/e2e/editor.cy.ts
+++ b/cypress/e2e/editor.cy.ts
@@ -1,12 +1,9 @@
 export {};
 
-type TestEditor = HTMLElement & {
-  shadowRoot: ShadowRoot;
-};
-
+type TestHaForm = HTMLElement;
 declare global {
-  interface Window {
-    testEditor: TestEditor;
+    interface Window {
+    testForm: TestHaForm;
   }
 }
 
@@ -18,16 +15,8 @@ describe('Editor', () => {
 
   function getHaForm() {
     return cy.window()
-        .its('testEditor')
-        .should('exist')
-        .then(editor => {
-        const testEditor = editor as unknown as TestEditor;
-        const form = testEditor.shadowRoot.querySelector('ha-form');
-
-        expect(form).to.exist;
-
-        return cy.wrap(form);
-        });
+    .its('testForm')
+    .should('exist');
   }
 
   function input(name: string) {

--- a/cypress/e2e/editor.cy.ts
+++ b/cypress/e2e/editor.cy.ts
@@ -1,27 +1,18 @@
 export {};
 
-type TestHaForm = HTMLElement;
-declare global {
-    interface Window {
-    testForm: TestHaForm;
-  }
-}
-
 describe('Editor', () => {
   beforeEach(() => {
     cy.visit('editor-harness.html');
     cy.window().should('have.property', 'editorReady', true);
   });
 
-  function getHaForm() {
-    return cy.window()
-    .its('testForm')
-    .should('exist');
-  }
-
   function input(name: string) {
-    return getHaForm().find(`input[data-name="${name}"]`);
-  }
+    return cy
+        .get('hourly-weather-editor')
+        .shadow()
+        .find(`input[data-name="${name}"]`)
+        .should('exist');
+    }
 
   it('does not disable precipitation switches by default', () => {
     input('show_expected_precipitation')
@@ -70,6 +61,7 @@ describe('Editor', () => {
       .then(async ($editor) => {
         const editor = $editor[0] as HTMLElement & {
           setConfig(config: Record<string, unknown>): Promise<void>;
+          updateComplete: Promise<boolean>;
         };
 
         await editor.setConfig({
@@ -79,6 +71,8 @@ describe('Editor', () => {
           show_precipitation_amounts: false,
           show_precipitation_probability: false,
         });
+
+        await editor.updateComplete;
       });
 
     input('show_precipitation_amounts')

--- a/cypress/e2e/weather-bar.cy.ts
+++ b/cypress/e2e/weather-bar.cy.ts
@@ -1342,22 +1342,29 @@ describe('Weather bar', () => {
         });
     });
 
-    it('shows expected precipitation if specified in config (overrules show_precipitation_amount config setting)', () => {
+    it('shows aggregated expected precipitation if specified in config (overrules show_precipitation_amount config setting)', () => {
       cy.configure({
         show_precipitation_amounts: true,
         show_expected_precipitation: true,
-        label_spacing: '1'
+        label_spacing: '2'
       });
       cy.get('weather-bar')
         .shadow()
         .find('div.axes > div.bar-block div.precipitation')
         .should('have.length', 12)
         .each((el, i) => {
-            if (expectedPrecipitation[i] === 0 || expectedPrecipitationProbability[i] === 0) {
+          if (i % 2 === 0) {
+            const firstExpectedPrecipitation = Math.round(expectedPrecipitation[i] * expectedPrecipitationProbability[i])/100;
+            const secondExpectedPrecipitation = Math.round(expectedPrecipitation[i+1] * expectedPrecipitationProbability[i+1])/100;
+            const aggregatedExpectedPrecipitation = firstExpectedPrecipitation + secondExpectedPrecipitation;
+            if (aggregatedExpectedPrecipitation === 0) {
               cy.wrap(el).should('be.empty');
             } else {
-              cy.wrap(el).should('have.text', `${Math.round(expectedPrecipitation[i] * expectedPrecipitationProbability[i])/100} in`);
+              cy.wrap(el).should('have.text', `${aggregatedExpectedPrecipitation} in`);
             }
+          } else {
+            cy.wrap(el).should('be.empty');
+          }
         });
     });
   });

--- a/cypress/e2e/weather-bar.cy.ts
+++ b/cypress/e2e/weather-bar.cy.ts
@@ -1301,6 +1301,65 @@ describe('Weather bar', () => {
           }
         });
     });
+
+    it('does not show probabilities if expected precipitation specified in config', () => {
+      cy.configure({
+        show_precipitation_probability: true,
+        show_expected_precipitation: true,
+        label_spacing: '1'
+      });
+      cy.get('weather-bar')
+        .shadow()
+        .find('div.axes > div.bar-block div.precipitation')
+        .should('have.length', 12)
+        .each((el, i) => {
+          if (expectedPrecipitation[i] === 0 || expectedPrecipitationProbability[i] === 0) {
+            cy.wrap(el.text()).should('be.empty');
+          } else {
+            cy.wrap(el).should('not.include.text', `%`)
+              .should('have.text', `${Math.round(expectedPrecipitation[i] * expectedPrecipitationProbability[i])/100} in`)
+              .find('span')
+              .should('not.exist');
+          }
+        });
+    });
+
+    it('shows expected precipitation if specified in config', () => {
+      cy.configure({
+        show_expected_precipitation: true,
+        label_spacing: '1'
+      });
+      cy.get('weather-bar')
+        .shadow()
+        .find('div.axes > div.bar-block div.precipitation')
+        .should('have.length', 12)
+        .each((el, i) => {
+            if (expectedPrecipitation[i] === 0 || expectedPrecipitationProbability[i] === 0) {
+              cy.wrap(el).should('be.empty');
+            } else {
+              cy.wrap(el).should('have.text', `${Math.round(expectedPrecipitation[i] * expectedPrecipitationProbability[i])/100} in`);
+            }
+        });
+    });
+
+    it('shows expected precipitation if specified in config (overrules show_precipitation_amount config setting)', () => {
+      cy.configure({
+        show_precipitation_amounts: true,
+        show_expected_precipitation: true,
+        label_spacing: '1'
+      });
+      cy.get('weather-bar')
+        .shadow()
+        .find('div.axes > div.bar-block div.precipitation')
+        .should('have.length', 12)
+        .each((el, i) => {
+            if (expectedPrecipitation[i] === 0 || expectedPrecipitationProbability[i] === 0) {
+              cy.wrap(el).should('be.empty');
+            } else {
+              cy.wrap(el).should('have.text', `${Math.round(expectedPrecipitation[i] * expectedPrecipitationProbability[i])/100} in`);
+            }
+        });
+    });
   });
 });
 

--- a/cypress/fixtures/editor-harness.html
+++ b/cypress/fixtures/editor-harness.html
@@ -1,0 +1,123 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Hourly Weather Editor</title>
+
+  <script>
+    class TestHaForm extends HTMLElement {
+      set hass(value) {
+        this._hass = value;
+      }
+
+      set data(value) {
+        this._data = value;
+        this.render();
+      }
+
+      set schema(value) {
+        this._schema = value;
+        this.render();
+      }
+
+      get schema() {
+        return this._schema;
+      }
+
+      set computeLabel(value) {
+        this._computeLabel = value;
+      }
+
+      render() {
+        this.innerHTML = '';
+
+        for (const item of this._schema || []) {
+          const label = document.createElement('label');
+          const input = document.createElement('input');
+
+          input.type = 'checkbox';
+          input.dataset.name = item.name;
+          input.checked = Boolean(this._data?.[item.name]);
+          input.disabled = Boolean(item.disabled);
+
+          input.addEventListener('change', () => {
+            const value = {
+              ...(this._data || {}),
+              [item.name]: input.checked,
+            };
+
+            this._data = value;
+
+            this.dispatchEvent(
+              new CustomEvent('value-changed', {
+                detail: { value },
+                bubbles: true,
+                composed: true,
+              }),
+            );
+          });
+
+          label.textContent =
+            this._computeLabel?.(item) || item.name;
+          label.appendChild(input);
+          this.appendChild(label);
+        }
+      }
+    }
+
+    customElements.define('ha-form', TestHaForm);
+
+    window.loadCardHelpers = async () => ({
+      createCardElement() {
+        return document.createElement('div');
+      },
+    });
+  </script>
+
+  <script
+    src="../../dist/hourly-weather.js"
+    type="module">
+  </script>
+</head>
+
+<body>
+  <div id="wrapper"></div>
+
+  <script>
+    window.addEventListener('load', async () => {
+        const card = document.createElement('hourly-weather');
+
+        const editor = await card.constructor.getConfigElement();
+
+        // Cypress harness workaround for ScopedRegistryHost.
+        editor.constructor.prototype.createRenderRoot = function () {
+            return this.attachShadow({ mode: 'open' });
+        };
+
+        editor.hass = {
+            locale: {
+            language: 'en',
+            number_format: 'language',
+            time_format: 'language',
+            },
+        };
+
+        document.querySelector('#wrapper').appendChild(editor);
+
+        window.testEditor = editor;
+
+        await editor.setConfig({
+            type: 'custom:hourly-weather',
+            entity: 'weather.mock',
+            show_expected_precipitation: false,
+            show_precipitation_amounts: false,
+            show_precipitation_probability: false,
+        });
+
+        await new Promise(resolve => requestAnimationFrame(resolve));
+
+        window.editorReady = true;
+    });
+  </script>
+</body>
+</html>

--- a/cypress/fixtures/editor-harness.html
+++ b/cypress/fixtures/editor-harness.html
@@ -85,6 +85,41 @@
 
   <script>
     window.addEventListener('load', async () => {
+
+        function waitForHaForm(editor) {
+            return new Promise((resolve, reject) => {
+                const timeout = setTimeout(() => {
+                reject(new Error('ha-form was not rendered by hourly-weather-editor'));
+                }, 5000);
+
+                const findForm = () => {
+                const form = editor.renderRoot?.querySelector('ha-form');
+
+                if (form) {
+                    clearTimeout(timeout);
+                    observer?.disconnect();
+                    resolve(form);
+                }
+                };
+
+                const root = editor.renderRoot;
+
+                if (!root) {
+                reject(new Error('Editor renderRoot was not created'));
+                return;
+                }
+
+                const observer = new MutationObserver(findForm);
+
+                observer.observe(root, {
+                childList: true,
+                subtree: true,
+                });
+
+                findForm();
+            });
+        }
+
         const card = document.createElement('hourly-weather');
 
         const editor = await card.constructor.getConfigElement();
@@ -104,8 +139,6 @@
 
         document.querySelector('#wrapper').appendChild(editor);
 
-        window.testEditor = editor;
-
         await editor.setConfig({
             type: 'custom:hourly-weather',
             entity: 'weather.mock',
@@ -114,8 +147,7 @@
             show_precipitation_probability: false,
         });
 
-        await new Promise(resolve => requestAnimationFrame(resolve));
-
+        window.testForm = await waitForHaForm(editor);
         window.editorReady = true;
     });
   </script>

--- a/cypress/fixtures/editor-harness.html
+++ b/cypress/fixtures/editor-harness.html
@@ -86,40 +86,6 @@
   <script>
     window.addEventListener('load', async () => {
 
-        function waitForHaForm(editor) {
-            return new Promise((resolve, reject) => {
-                const timeout = setTimeout(() => {
-                reject(new Error('ha-form was not rendered by hourly-weather-editor'));
-                }, 5000);
-
-                const findForm = () => {
-                const form = editor.renderRoot?.querySelector('ha-form');
-
-                if (form) {
-                    clearTimeout(timeout);
-                    observer?.disconnect();
-                    resolve(form);
-                }
-                };
-
-                const root = editor.renderRoot;
-
-                if (!root) {
-                reject(new Error('Editor renderRoot was not created'));
-                return;
-                }
-
-                const observer = new MutationObserver(findForm);
-
-                observer.observe(root, {
-                childList: true,
-                subtree: true,
-                });
-
-                findForm();
-            });
-        }
-
         const card = document.createElement('hourly-weather');
 
         const editor = await card.constructor.getConfigElement();
@@ -147,7 +113,7 @@
             show_precipitation_probability: false,
         });
 
-        window.testForm = await waitForHaForm(editor);
+        await editor.updateComplete;
         window.editorReady = true;
     });
   </script>

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -12,6 +12,7 @@ interface HaFormSchema {
   label?: string;
   selector?: Record<string, any>;
   required?: boolean;
+  disabled?: boolean;
   type?: string;
   default?: any;
 }
@@ -71,6 +72,10 @@ export class HourlyWeatherCardEditor extends ScopedRegistryHost(LitElement) impl
 
   get _show_precipitation_probability(): boolean {
     return this._config?.show_precipitation_probability ?? false;
+  }
+
+  get _show_expected_precipitation(): boolean {
+    return this._config?.show_expected_precipitation ?? false;
   }
 
   get _offset(): string {
@@ -165,12 +170,18 @@ export class HourlyWeatherCardEditor extends ScopedRegistryHost(LitElement) impl
         },
       },
       {
+        name: 'show_expected_precipitation',
+        selector: { boolean: {} },
+      },
+      {
         name: 'show_precipitation_amounts',
         selector: { boolean: {} },
+        disabled: this._show_expected_precipitation,
       },
       {
         name: 'show_precipitation_probability',
         selector: { boolean: {} },
+        disabled: this._show_expected_precipitation,
       },
     ];
   }
@@ -197,6 +208,7 @@ export class HourlyWeatherCardEditor extends ScopedRegistryHost(LitElement) impl
         show_date: localize('editor.show_date'),
         show_precipitation_amounts: localize('editor.show_precipitation_amounts'),
         show_precipitation_probability: localize('editor.show_precipitation_probability'),
+        show_expected_precipitation: localize('editor.show_expected_precipitation'),
       };
 
       return labelMap[schemaItem.name] || schemaItem.name;

--- a/src/hourly-weather.ts
+++ b/src/hourly-weather.ts
@@ -324,6 +324,7 @@ export class HourlyWeatherCard extends LitElement {
     const icon_fill = config.icon_fill;
     const hideMinutes = !!config.hide_minutes;
     const roundTemperatures = !!config.round_temperatures;
+    const showExpectedPrecipitation = !!config.show_expected_precipitation;
 
     if (numSegments < 1) {
       // REMARK: Ok, so I'm re-using a localized string here. Probably not the best, but it avoids repeating for no good reason
@@ -382,7 +383,7 @@ export class HourlyWeatherCard extends LitElement {
     const conditionList = this.getConditionListFromForecast(forecast, numSegments, offset);
     const temperatures = this.getTemperatures(forecast, numSegments, offset, hideMinutes, roundTemperatures);
     const wind = this.getWind(forecast, numSegments, offset, windSpeedUnit, hideMinutes);
-    const precipitation = this.getPrecipitation(forecast, numSegments, offset, precipitationUnit, hideMinutes, labelSpacing);
+    const precipitation = this.getPrecipitation(forecast, numSegments, offset, precipitationUnit, hideMinutes, labelSpacing, showExpectedPrecipitation);
 
     const colorSettings = this.getColorSettings(config.colors);
 
@@ -391,9 +392,9 @@ export class HourlyWeatherCard extends LitElement {
         .header=${config.name}
         @action=${this._handleAction}
         .actionHandler=${actionHandler({
-      hasHold: hasAction(config.hold_action),
-      hasDoubleClick: hasAction(config.double_tap_action),
-    })}
+          hasHold: hasAction(config.hold_action),
+          hasDoubleClick: hasAction(config.double_tap_action),
+        })}
         tabindex="0"
         .label=${`Hourly Weather: ${config.entity || 'No Entity Defined'}`}
       >
@@ -414,8 +415,8 @@ export class HourlyWeatherCard extends LitElement {
             .hide_bar=${!!config.hide_bar}
             .icon_fill=${config.icon_fill}
             .show_wind=${showWind}
-            .show_precipitation_amounts=${!!config.show_precipitation_amounts}
-            .show_precipitation_probability=${!!config.show_precipitation_probability}
+            .show_precipitation_amounts=${!!config.show_precipitation_amounts || showExpectedPrecipitation}
+            .show_precipitation_probability=${!!config.show_precipitation_probability && !showExpectedPrecipitation}
             .show_date=${config.show_date}
             .label_spacing=${labelSpacing}
             .labels=${this.labels}></weather-bar>
@@ -458,7 +459,7 @@ export class HourlyWeatherCard extends LitElement {
     return temperatures;
   }
 
-  private getPrecipitation(forecast: ForecastSegment[], numSegments: number, offset: number, unit: string, hideMinutes: boolean, labelSpacing: number): SegmentPrecipitation[] {
+  private getPrecipitation(forecast: ForecastSegment[], numSegments: number, offset: number, unit: string, hideMinutes: boolean, labelSpacing: number, showExpectedPrecipitation: boolean): SegmentPrecipitation[] {
     const precipitation: SegmentPrecipitation[] = [];
 
     for (let i = 0; i < numSegments; i++) {
@@ -471,21 +472,26 @@ export class HourlyWeatherCard extends LitElement {
           Math.min(offset + i + labelSpacing, offset + numSegments),
         );
 
-        const totalAmount = interval.reduce(
-          (sum, segment) => sum + (Number(segment.precipitation) || 0),
-          0,
-        );
+        const totalAmount = interval.reduce((sum, segment) => {
+          const amount = Number(segment.precipitation) || 0;
+          const factor = showExpectedPrecipitation
+            ? (Number(segment.precipitation_probability) || 0) / 100
+            : 1;
+          return sum + amount * factor;
+        }, 0);
 
         // Probability for "rain at least once in this interval", assuming
         // independent segment probabilities.
-        const probability = 100 * (
-          1 - interval.reduce(
-            (noneProbability, segment) =>
-              noneProbability * (1 - (Number(segment.precipitation_probability) || 0) / 100),
-            1,
+        const probability = !showExpectedPrecipitation
+          ? 100 * (
+            1 - interval.reduce(
+              (noneProbability, segment) =>
+                noneProbability * (1 - (Number(segment.precipitation_probability) || 0) / 100),
+              1,
+            )
           )
-        );
-        const roundedProbability = Math.round(probability);
+          : undefined;
+        const roundedProbability = probability !== undefined ? Math.round(probability) : undefined;
 
         precipitation.push({
           hour: this.formatHour(new Date(fs.datetime), this.hass.locale, hideMinutes),
@@ -494,11 +500,11 @@ export class HourlyWeatherCard extends LitElement {
               ? `${formatNumber(totalAmount, this.hass.locale)} ${unit}`.trim()
               : '',
           precipitationProbability:
-            roundedProbability > 0
+            roundedProbability !== undefined && roundedProbability > 0
               ? `${formatNumber(roundedProbability, this.hass.locale)}%`
               : '',
           precipitationProbabilityText:
-            roundedProbability > 0
+            roundedProbability !== undefined && roundedProbability > 0
               ? this.localize(
                   'card.chance_of_precipitation',
                   '{0}',

--- a/src/localize/languages/bg.json
+++ b/src/localize/languages/bg.json
@@ -17,6 +17,7 @@
     "show_date": "Показвай дати",
     "show_precipitation_amounts": "Покажи количеството валежи",
     "show_precipitation_probability": "Покажи вероятноста за валежи",
+    "show_expected_precipitation": "Показване на очакваните валежи (прогнозно количество * вероятност)",
     "none": "Няма",
     "speed_and_direction": "Скорост и посока",
     "speed_only": "Само скорост",

--- a/src/localize/languages/cs.json
+++ b/src/localize/languages/cs.json
@@ -17,6 +17,7 @@
     "show_date": "Zobrazit datumy",
     "show_precipitation_amounts": "Zobrazit množství srážek",
     "show_precipitation_probability": "Zobrazit pravdědpodobnost srážek",
+    "show_expected_precipitation": "Zobrazit očekávané srážky (předpokládané množství * pravděpodobnost)",
     "none": "Žádné",
     "speed_and_direction": "Rychlost a směr",
     "speed_only": "Jen rychlost",

--- a/src/localize/languages/da.json
+++ b/src/localize/languages/da.json
@@ -16,6 +16,7 @@
     "show_wind": "Vis vindhastighed og retning",
     "show_precipitation_amounts": "Vis nedbørsmængde",
     "show_precipitation_probability": "Vis nedbørssandsynlighed",
+    "show_expected_precipitation": "Vis forventet nedbør (forventet mængde * sandsynlighed)",
     "none": "Ingen",
     "speed_and_direction": "Hastighed og retning",
     "speed_only": "Kun hastighed",

--- a/src/localize/languages/de.json
+++ b/src/localize/languages/de.json
@@ -15,6 +15,7 @@
     "label_spacing": "Anzahl der Vorhersagesegmente für Raumzeit- und Temperaturbeschriftungen nach (optional)",
     "show_wind": "Zeigt Windgeschwindigkeit und -richtung an",
     "show_precipitation_amounts": "Niederschlagsmenge anzeigen",
+    "show_expected_precipitation": "Erwarteten Niederschlag anzeigen (Vorhersagemenge * Wahrscheinlichkeit)",
     "speed_only": "Nur Geschwindigkeit",
     "direction_only": "Nur Richtung",
     "barb": "Als Windbarbe",

--- a/src/localize/languages/en.json
+++ b/src/localize/languages/en.json
@@ -17,6 +17,7 @@
     "show_date": "Show dates",
     "show_precipitation_amounts": "Show precipitation amount",
     "show_precipitation_probability": "Show precipitation probability",
+    "show_expected_precipitation": "Show expected precipitation (forecast amount * probability)",
     "none": "None",
     "speed_and_direction": "Speed and direction",
     "speed_only": "Speed only",

--- a/src/localize/languages/es.json
+++ b/src/localize/languages/es.json
@@ -15,6 +15,7 @@
     "label_spacing": "Número de segmentos de pronóstico para etiquetas de temperatura y tiempo espacial por (Opcional)",
     "show_wind": "Mostrar la velocidad y dirección del viento",
     "show_precipitation_amounts": "Mostrar cantidad de precipitación",
+    "show_expected_precipitation": "Mostrar precipitación esperada (cantidad prevista * probabilidad)",
     "speed_only": "Solo velocidad",
     "direction_only": "Solo dirección",
     "barb": "Como púa de viento",

--- a/src/localize/languages/fr.json
+++ b/src/localize/languages/fr.json
@@ -15,6 +15,7 @@
     "label_spacing": "Segments d'espacement entre les étiquettes d'heure et de température (facultatif)",
     "show_wind": "Afficher la vitesse et la direction du vent",
     "show_precipitation_amounts": "Afficher la quantité de précipitations",
+    "show_expected_precipitation": "Afficher les précipitations attendues (quantité prévue * probabilité)",
     "speed_only": "Vitesse uniquement",
     "direction_only": "Sens uniquement",
     "barb": "Comme barbillon de vent",

--- a/src/localize/languages/hu.json
+++ b/src/localize/languages/hu.json
@@ -16,6 +16,7 @@
     "show_wind": "Szélsebesség és irány megjelenítése",
     "show_precipitation_amounts": "Csapadékmennyiség megjelenítése",
     "show_precipitation_probability": "Csapadék valószínűségének megjelenítése",
+    "show_expected_precipitation": "Várható csapadék megjelenítése (előrejelzett mennyiség * valószínűség)",
     "speed_only": "Sebesség",
     "direction_only": "Irány",
     "barb": "Irány nyílként",

--- a/src/localize/languages/it.json
+++ b/src/localize/languages/it.json
@@ -15,6 +15,7 @@
     "label_spacing": "Numero di segmenti di previsione per spazio etichette tempo e temperatura per (facoltativo)",
     "show_wind": "Mostra la velocità e la direzione del vento",
     "show_precipitation_amounts": "Mostra la quantità di precipitazioni",
+    "show_expected_precipitation": "Mostra precipitazioni previste (quantità prevista * probabilità)",
     "speed_only": "Solo velocità",
     "direction_only": "Solo direzione",
     "barb": "Come una punta di vento",

--- a/src/localize/languages/nb.json
+++ b/src/localize/languages/nb.json
@@ -15,6 +15,7 @@
     "label_spacing": "Antall prognosesegmenter til romtid og temperaturetiketter etter (valgfritt)",
     "show_wind": "Vis vindhastighet og retning",
     "show_precipitation_amounts": "Vis nedbørsmengde",
+    "show_expected_precipitation": "Vis forventet nedbør (forventet mengde * sannsynlighet)",
     "speed_only": "Kun hastighet",
     "direction_only": "Kun retning",
     "barb": "Som vindmothak",

--- a/src/localize/languages/nl.json
+++ b/src/localize/languages/nl.json
@@ -19,6 +19,7 @@
     "direction_only": "Alleen richting (tekst)",
     "barb": "Alleen richting (pijl)",
     "show_precipitation_probability": "Neerslagkans weergeven",
+    "show_expected_precipitation": "Verwachte neerslag weergeven (verwachte hoeveelheid * kans)",
     "none": "Geen",
     "speed_and_direction": "Snelheid en richting",
     "barb_and_speed": "Zoals wind weerhaak en snelheid",

--- a/src/localize/languages/nn-NO.json
+++ b/src/localize/languages/nn-NO.json
@@ -15,6 +15,7 @@
     "label_spacing": "Antall prognosesegment til romtid og temperaturetikettar etter (valfritt)",
     "show_wind": "Vis vindhastigheit og retning",
     "show_precipitation_amounts": "Vis nedbørsmengde",
+    "show_expected_precipitation": "Vis forventa nedbør (forventa mengd * sannsyn)",
     "neither": "Ingen",
     "both": "Både",
     "speed_only": "Kun hastigheit",

--- a/src/localize/languages/pl.json
+++ b/src/localize/languages/pl.json
@@ -19,6 +19,7 @@
     "direction_only": "Tylko kierunek",
     "barb": "Jak kolce wiatru",
     "show_precipitation_probability": "Pokaż prawdopodobieństwo opadów",
+    "show_expected_precipitation": "Pokaż oczekiwane opady (prognozowana ilość * prawdopodobieństwo)",
     "none": "Nic",
     "speed_and_direction": "Szybkość i kierunek",
     "barb_and_speed": "Jak kolce wiatru i prędkość",

--- a/src/localize/languages/pt-BR.json
+++ b/src/localize/languages/pt-BR.json
@@ -15,6 +15,7 @@
     "label_spacing": "Número de segmentos de previsão para rótulos de tempo e temperatura de espaço por (opcional)",
     "show_wind": "Mostrar velocidade e direção do vento",
     "show_precipitation_amounts": "Mostrar quantidade de precipitação",
+    "show_expected_precipitation": "Mostrar precipitação esperada (quantidade prevista * probabilidade)",
     "neither": "Nenhum",
     "both": "Ambos",
     "speed_only": "Apenas velocidade",

--- a/src/localize/languages/pt.json
+++ b/src/localize/languages/pt.json
@@ -15,6 +15,7 @@
     "label_spacing": "Número de segmentos de previsão para rótulos de tempo e temperatura de espaço por (opcional)",
     "show_wind": "Mostrar velocidade e direção do vento",
     "show_precipitation_amounts": "Mostrar quantidade de precipitação",
+    "show_expected_precipitation": "Mostrar precipitação esperada (quantidade prevista * probabilidade)",
     "speed_only": "Apenas velocidade",
     "direction_only": "Apenas direção",
     "barb": "Como farpa de vento",

--- a/src/localize/languages/ru.json
+++ b/src/localize/languages/ru.json
@@ -17,6 +17,7 @@
     "show_date": "Отображать даты",
     "show_precipitation_amounts": "Отображать количество осадков",
     "show_precipitation_probability": "Отображать вероятность осадков",
+    "show_expected_precipitation": "Показать ожидаемые осадки (прогнозируемое количество * вероятность)",
     "none": "Нет",
     "speed_and_direction": "Скорость и направление",
     "speed_only": "Только скорость",

--- a/src/localize/languages/sk.json
+++ b/src/localize/languages/sk.json
@@ -16,6 +16,7 @@
     "show_wind": "Zobraziť rýchlosť a smer vetra",
     "show_precipitation_amounts": "Zobraziť množstvo zrážok",
     "show_precipitation_probability": "Zobraziť pravdepodobnosť zrážok",
+    "show_expected_precipitation": "Zobraziť očakávané zrážky (predpokladané množstvo * pravdepodobnosť)",
     "none": "Nič",
     "speed_and_direction": "Rýchlosť a smer",
     "speed_only": "Len rýchlosť",

--- a/src/localize/languages/tr.json
+++ b/src/localize/languages/tr.json
@@ -17,6 +17,7 @@
     "show_date": "Tarihleri göster",
     "show_precipitation_amounts": "Yağış miktarını göster",
     "show_precipitation_probability": "Yağış olasılığını göster",
+    "show_expected_precipitation": "Beklenen yağışı göster (tahmin edilen miktar * olasılık)",
     "none": "Yok",
     "speed_and_direction": "Hız ve yön",
     "speed_only": "Sadece hız",

--- a/src/localize/languages/uk.json
+++ b/src/localize/languages/uk.json
@@ -17,6 +17,7 @@
     "show_date": "Показувати дати",
     "show_precipitation_amounts": "Показувати кількість опадів",
     "show_precipitation_probability": "Показувати ймовірність опадів",
+    "show_expected_precipitation": "Показати очікувані опади (прогнозована кількість * ймовірність)",
     "none": "Нічого",
     "speed_and_direction": "Швидкість та напрямок",
     "speed_only": "Тільки швидкість",

--- a/src/localize/languages/zh.json
+++ b/src/localize/languages/zh.json
@@ -17,6 +17,7 @@
     "show_date": "显示日期",
     "show_precipitation_amounts": "显示降雨量",
     "show_precipitation_probability": "显示降雨概率",
+    "show_expected_precipitation": "显示预计降水量 (预报量 * 概率)",
     "none": "无",
     "speed_and_direction": "速度和方向",
     "speed_only": "仅速度",

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,6 +35,7 @@ export interface HourlyWeatherCardConfig extends LovelaceCardConfig {
   show_wind?: WindType | boolean; // 'true' | 'false' | 'speed' | 'direction' | 'barb' | 'barb-and-speed' | 'barb-and-direction' | 'barb-speed-and-direction'
   show_precipitation_amounts?: boolean;
   show_precipitation_probability?: boolean;
+  show_expected_precipitation?: boolean;
   show_date?: ShowDateType; // 'false' | 'boundary' | 'all'
   label_spacing?: string; // number
   test_gui?: boolean;

--- a/src/weather-bar.ts
+++ b/src/weather-bar.ts
@@ -52,6 +52,9 @@ export class WeatherBar extends LitElement {
   @property({ type: Boolean })
   show_precipitation_probability = false;
 
+  @property({ type: Boolean })
+  show_exptected_precipitation = false;
+
   @property({ type: String })
   show_date: ShowDateType = 'false';
 
@@ -115,8 +118,8 @@ export class WeatherBar extends LitElement {
       const showWindSpeed = (windCfg === 'true' || windCfg.includes('speed')) && !skipLabel;
       const showWindDirection = (windCfg === 'true' || windCfg.includes('direction')) && !skipLabel;
       const showWindBarb = windCfg.includes('barb') && !skipLabel;
-      const showPrecipitationAmounts = this.show_precipitation_amounts && !skipLabel;
-      const showPrecipitationProbability = this.show_precipitation_probability && !skipLabel;
+      const showPrecipitationAmounts = (this.show_precipitation_amounts || this.show_exptected_precipitation) && !skipLabel;
+      const showPrecipitationProbability = this.show_precipitation_probability && !this.show_exptected_precipitation && !skipLabel;
       const { hour, date, temperature } = this.temperatures[i];
       let renderedDate: string | TemplateResult | null = null;
       if (!skipLabel && this.show_date && this.show_date !== 'false') {


### PR DESCRIPTION
Added optional feature to display expected precipitation, calculated as forecast amount x probability, instead of amount and/or probability. This allows user to save space and get a better picture of the precipitation forecast. Enabling this option automatically disables the other options to display amount/probability in UI editor and if set to `true` in YAML editor they get overruled by this new setting. This ensures that either the expected precipitation is shown *or* the forecast values are shown and never a combination of both.

For aggregated values the expected precipitation values of the individual segments are summed up.

Fixes: #948 