### PR TITLE
Recover stalled forecast subscriptions

### DIFF
--- a/cypress/e2e/card.cy.ts
+++ b/cypress/e2e/card.cy.ts
@@ -51,27 +51,12 @@ describe('Card', () => {
       .find('p')
       .should('have.text', 'Check the configured forecast entity.');
   });
-  it('handles graceful transient error if forecast is there by attribute, but not with the right amount of segments', () => {
+  it('keeps its layout while a forecast subscription is pending', () => {
     cy.enableForecastSubscriptions();
 
-    const forecast1 = [
-      {
-        "datetime": "2022-07-21T17:00:00+00:00",
-        "precipitation": 0,
-        "precipitation_probability": 0,
-        "pressure": 1007,
-        "wind_speed": 4.67,
-        "wind_bearing": 'WSW',
-        "condition": "cloudy" as Condition,
-        "clouds": 60,
-        "temperature": 84
-      },
-    ];
     cy.addEntity({
       'weather.fromSub': {
-        attributes: {
-          forecast: forecast1
-        }
+        attributes: {}
       }
     });
     cy.configure({
@@ -79,7 +64,9 @@ describe('Card', () => {
       num_segments: '2'
     });
     cy.get('ha-card')
-      .should('not.exist');
+      .should('exist')
+      .find('.forecast-pending')
+      .should('have.attr', 'aria-busy', 'true');
 
     const forecast2 = [
       {
@@ -109,5 +96,37 @@ describe('Card', () => {
     cy.updateLastForecastSubscription(forecast2);
     cy.get('ha-card')
       .should('exist');
+  });
+
+  it('keeps the last good forecast when a subscription emits an empty refresh', () => {
+    cy.enableForecastSubscriptions();
+    cy.configure({ entity: 'weather.mock' });
+    cy.get('weather-bar').should('exist');
+
+    cy.updateLastForecastSubscription([]);
+    cy.get('weather-bar').should('exist');
+    cy.get('.forecast-pending').should('not.exist');
+  });
+
+  it('recovers a stalled subscription through weather.get_forecasts', () => {
+    cy.enableForecastSubscriptions();
+    cy.addEntity({
+      'weather.stalled': { attributes: {} }
+    });
+    cy.configure({ entity: 'weather.stalled', num_segments: '1' });
+    cy.get('.forecast-pending').should('exist');
+
+    cy.window().then((win: any) => {
+      cy.addFallbackForecast('weather.stalled', win.hourlyWeather.hass.states['weather.mock'].attributes.forecast);
+    });
+    cy.recoverForecast();
+
+    cy.get('weather-bar').should('exist');
+    cy.window().its('lastHWCallWS').should('deep.include', {
+      type: 'call_service',
+      domain: 'weather',
+      service: 'get_forecasts',
+      return_response: true,
+    });
   });
 });

--- a/cypress/e2e/card.cy.ts
+++ b/cypress/e2e/card.cy.ts
@@ -119,6 +119,26 @@ describe('Card', () => {
     cy.window().should('not.have.property', 'lastHWCallWS');
   });
 
+  it('re-establishes a failed subscription while the last forecast is fresh', () => {
+    cy.enableForecastSubscriptions();
+    cy.configure({ entity: 'weather.mock' });
+    cy.get('weather-bar').should('exist');
+
+    cy.window().then(async (win: any) => {
+      const card = win.hourlyWeather;
+      const subscribe = cy.spy(card.hass.connection, 'subscribeMessage');
+      card.subscribedToForecast = undefined;
+
+      await card.recoverForecast();
+
+      expect(subscribe).to.have.been.calledWithMatch(
+        Cypress.sinon.match.func,
+        { type: 'weather/subscribe_forecast', entity_id: 'weather.mock' }
+      );
+      expect(win.lastHWCallWS).to.equal(undefined);
+    });
+  });
+
   it('recovers a stalled subscription through weather.get_forecasts', () => {
     cy.enableForecastSubscriptions();
     cy.addEntity({

--- a/cypress/e2e/card.cy.ts
+++ b/cypress/e2e/card.cy.ts
@@ -108,6 +108,17 @@ describe('Card', () => {
     cy.get('.forecast-pending').should('not.exist');
   });
 
+  it('does not recover while the last valid subscription update is fresh', () => {
+    cy.enableForecastSubscriptions();
+    cy.configure({ entity: 'weather.mock' });
+    cy.get('weather-bar').should('exist');
+
+    cy.updateLastForecastSubscription([]);
+    cy.recoverForecast();
+
+    cy.window().should('not.have.property', 'lastHWCallWS');
+  });
+
   it('recovers a stalled subscription through weather.get_forecasts', () => {
     cy.enableForecastSubscriptions();
     cy.addEntity({

--- a/cypress/fixtures/harness.html
+++ b/cypress/fixtures/harness.html
@@ -590,6 +590,17 @@
       },
       locale: {language: 'en', number_format: 'language', time_format: 'language'}
     }
+    h.hass.callWS = async message => {
+      window.lastHWCallWS = message;
+      const entityId = message?.target?.entity_id;
+      return {
+        response: {
+          [entityId]: {
+            forecast: window.HWFallbackForecasts?.[entityId]
+          }
+        }
+      };
+    };
     w.appendChild(h);
     window.hourlyWeather = h;
     window.addEventListener('load', () => {
@@ -602,7 +613,10 @@
         }
       };
       window.HWForecasts = {};
+      window.HWFallbackForecasts = {};
       window.addHWForecast = (entityId, forecast) => window.HWForecasts[entityId] = forecast;
+      window.addHWFallbackForecast = (entityId, forecast) => window.HWFallbackForecasts[entityId] = forecast;
+      window.recoverHWForecast = () => h.recoverForecast();
       window.enableHWForecastSubscriptions = () => h.hass = {
         ...h.hass,
         services: {

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -56,6 +56,14 @@ Cypress.Commands.add('addForecast', (entityId: string, forecast: ForecastSegment
   cy.window().invoke('addHWForecast', entityId, forecast).wait(1);
 });
 
+Cypress.Commands.add('addFallbackForecast', (entityId: string, forecast: ForecastSegment[]) => {
+  cy.window().invoke('addHWFallbackForecast', entityId, forecast).wait(1);
+});
+
+Cypress.Commands.add('recoverForecast', () => {
+  cy.window().invoke('recoverHWForecast').wait(1);
+});
+
 Cypress.Commands.add('enableForecastSubscriptions', () => {
   cy.window().invoke('enableHWForecastSubscriptions').wait(1);
 });
@@ -101,6 +109,8 @@ declare global {
       configure(config: Partial<HourlyWeatherCardConfig>, noDefaults?: boolean): Chainable<void>;
       addEntity(entities: Record<string, WeatherEntity>): Chainable<void>;
       addForecast(entityId: string, forecast: ForecastSegment[]): Chainable<void>;
+      addFallbackForecast(entityId: string, forecast: ForecastSegment[]): Chainable<void>;
+      recoverForecast(): Chainable<void>;
       enableForecastSubscriptions(): Chainable<void>;
       updateLastForecastSubscription(forecast: ForecastSegment[]): Chainable<void>;
       setHomeLocation(latitude: number, longitude: number): Chainable<void>;

--- a/src/hourly-weather.ts
+++ b/src/hourly-weather.ts
@@ -145,8 +145,9 @@ export class HourlyWeatherCard extends LitElement {
 
   private unsubscribeForecastEvents() {
     if (this.subscribedToForecast) {
-      this.subscribedToForecast.then((unsub) => unsub()).catch(() => void 0);
+      const subscription = this.subscribedToForecast;
       this.subscribedToForecast = undefined;
+      Promise.resolve(subscription).then((unsub) => unsub()).catch(() => void 0);
     }
   }
 

--- a/src/hourly-weather.ts
+++ b/src/hourly-weather.ts
@@ -33,6 +33,7 @@ import type {
   DisplayCondition,
   ForecastEvent,
   ForecastSegment,
+  ForecastServiceCallResult,
   ForecastType,
   HourlyWeatherCardConfig,
   LocalizerLastSettings,
@@ -90,6 +91,7 @@ export class HourlyWeatherCard extends LitElement {
 
   private forecastRecoveryTimer?: number;
   private forecastRecoveryPending = false;
+  private lastValidForecastAt?: number;
 
   private configRenderPending = false;
 
@@ -154,15 +156,25 @@ export class HourlyWeatherCard extends LitElement {
 
   private acceptForecastEvent(event: ForecastEvent): boolean {
     if (!this.hasUsableForecast(event?.forecast)) {
-      this.scheduleForecastRecovery(INITIAL_FORECAST_RECOVERY_DELAY_MS);
+      this.scheduleForecastRecovery(this.getForecastRecoveryDelay());
       return false;
     }
 
     // Ignore transient empty subscription updates so a refresh cannot replace
     // a working card with a zero-height pending render.
     this.forecastEvent = event;
+    this.lastValidForecastAt = Date.now();
     this.scheduleForecastRecovery(FORECAST_STALE_AFTER_MS);
     return true;
+  }
+
+  private getForecastRecoveryDelay(): number {
+    if (this.lastValidForecastAt === undefined) {
+      return INITIAL_FORECAST_RECOVERY_DELAY_MS;
+    }
+
+    const forecastAge = Date.now() - this.lastValidForecastAt;
+    return Math.max(0, FORECAST_STALE_AFTER_MS - forecastAge);
   }
 
   private stopForecastRecovery() {
@@ -189,12 +201,18 @@ export class HourlyWeatherCard extends LitElement {
       return;
     }
 
+    const recoveryDelay = this.getForecastRecoveryDelay();
+    if (this.lastValidForecastAt !== undefined && recoveryDelay > 0) {
+      this.scheduleForecastRecovery(recoveryDelay);
+      return;
+    }
+
     const entityId = this.config.entity;
     const forecastType = this.getIdealForecastType();
     this.forecastRecoveryPending = true;
 
     try {
-      const result: any = await this.hass.callWS({
+      const result = await this.hass.callWS<ForecastServiceCallResult>({
         type: 'call_service',
         domain: 'weather',
         service: 'get_forecasts',
@@ -202,7 +220,7 @@ export class HourlyWeatherCard extends LitElement {
         target: { entity_id: entityId },
         return_response: true,
       });
-      const response = result?.response ?? result?.service_response ?? result;
+      const response = result.response ?? result.service_response;
       const forecast = response?.[entityId]?.forecast;
       if (this.hasUsableForecast(forecast)) {
         this.acceptForecastEvent({ type: forecastType, forecast });
@@ -245,7 +263,7 @@ export class HourlyWeatherCard extends LitElement {
       });
       this.scheduleForecastRecovery(
         this.hasUsableForecast(this.forecastEvent?.forecast)
-          ? FORECAST_STALE_AFTER_MS
+          ? this.getForecastRecoveryDelay()
           : INITIAL_FORECAST_RECOVERY_DELAY_MS
       );
     } catch (error) {
@@ -390,6 +408,7 @@ export class HourlyWeatherCard extends LitElement {
 
     if (entityChanged || forecastTypeChanged) {
       this.forecastEvent = undefined;
+      this.lastValidForecastAt = undefined;
     }
     if (!this.subscribedToForecast || entityChanged || forecastTypeChanged) {
       this.subscribeToForecastEvents();

--- a/src/hourly-weather.ts
+++ b/src/hourly-weather.ts
@@ -202,6 +202,10 @@ export class HourlyWeatherCard extends LitElement {
       return;
     }
 
+    if (!this.subscribedToForecast) {
+      await this.subscribeToForecastEvents();
+    }
+
     const recoveryDelay = this.getForecastRecoveryDelay();
     if (this.lastValidForecastAt !== undefined && recoveryDelay > 0) {
       this.scheduleForecastRecovery(recoveryDelay);
@@ -233,9 +237,6 @@ export class HourlyWeatherCard extends LitElement {
       this.forecastRecoveryPending = false;
     }
 
-    if (!this.subscribedToForecast) {
-      await this.subscribeToForecastEvents();
-    }
     this.scheduleForecastRecovery(FORECAST_RECOVERY_RETRY_MS);
   }
 

--- a/src/hourly-weather.ts
+++ b/src/hourly-weather.ts
@@ -47,6 +47,10 @@ customElements.define('weather-bar', WeatherBar);
 // Naive localizer is used before we can get at card configuration data
 const naiveLocalizer = getLocalizer(void 0, void 0);
 
+const INITIAL_FORECAST_RECOVERY_DELAY_MS = 1500;
+const FORECAST_RECOVERY_RETRY_MS = 30000;
+const FORECAST_STALE_AFTER_MS = 35 * 60 * 1000;
+
 /* eslint no-console: 0 */
 console.info(
   `%c  HOURLY-WEATHER-CARD \n%c  ${naiveLocalizer('common.version')} ${version}    `,
@@ -83,6 +87,9 @@ export class HourlyWeatherCard extends LitElement {
 
   @state() private forecastEvent?: ForecastEvent;
   @state() private subscribedToForecast?: Promise<() => void>;
+
+  private forecastRecoveryTimer?: number;
+  private forecastRecoveryPending = false;
 
   private configRenderPending = false;
 
@@ -136,9 +143,81 @@ export class HourlyWeatherCard extends LitElement {
 
   private unsubscribeForecastEvents() {
     if (this.subscribedToForecast) {
-      this.subscribedToForecast.then((unsub) => unsub());
+      this.subscribedToForecast.then((unsub) => unsub()).catch(() => void 0);
       this.subscribedToForecast = undefined;
     }
+  }
+
+  private hasUsableForecast(forecast: ForecastSegment[] | null | undefined): forecast is ForecastSegment[] {
+    return Array.isArray(forecast) && forecast.length > 0;
+  }
+
+  private acceptForecastEvent(event: ForecastEvent): boolean {
+    if (!this.hasUsableForecast(event?.forecast)) {
+      this.scheduleForecastRecovery(INITIAL_FORECAST_RECOVERY_DELAY_MS);
+      return false;
+    }
+
+    // Ignore transient empty subscription updates so a refresh cannot replace
+    // a working card with a zero-height pending render.
+    this.forecastEvent = event;
+    this.scheduleForecastRecovery(FORECAST_STALE_AFTER_MS);
+    return true;
+  }
+
+  private stopForecastRecovery() {
+    if (this.forecastRecoveryTimer !== undefined) {
+      window.clearTimeout(this.forecastRecoveryTimer);
+      this.forecastRecoveryTimer = undefined;
+    }
+  }
+
+  private scheduleForecastRecovery(delayMs: number) {
+    this.stopForecastRecovery();
+    if (!this.isConnected || !this.hass || !this.config?.entity || !this.hassSupportsForecastEvents()) {
+      return;
+    }
+
+    this.forecastRecoveryTimer = window.setTimeout(() => {
+      this.forecastRecoveryTimer = undefined;
+      void this.recoverForecast();
+    }, delayMs);
+  }
+
+  private async recoverForecast() {
+    if (this.forecastRecoveryPending || !this.isConnected || !this.hass?.callWS || !this.config?.entity) {
+      return;
+    }
+
+    const entityId = this.config.entity;
+    const forecastType = this.getIdealForecastType();
+    this.forecastRecoveryPending = true;
+
+    try {
+      const result: any = await this.hass.callWS({
+        type: 'call_service',
+        domain: 'weather',
+        service: 'get_forecasts',
+        service_data: { type: forecastType },
+        target: { entity_id: entityId },
+        return_response: true,
+      });
+      const response = result?.response ?? result?.service_response ?? result;
+      const forecast = response?.[entityId]?.forecast;
+      if (this.hasUsableForecast(forecast)) {
+        this.acceptForecastEvent({ type: forecastType, forecast });
+        return;
+      }
+    } catch (error) {
+      console.warn('[hourly-weather] forecast recovery failed', error);
+    } finally {
+      this.forecastRecoveryPending = false;
+    }
+
+    if (!this.subscribedToForecast) {
+      await this.subscribeToForecastEvents();
+    }
+    this.scheduleForecastRecovery(FORECAST_RECOVERY_RETRY_MS);
   }
 
   private async subscribeToForecastEvents() {
@@ -148,13 +227,31 @@ export class HourlyWeatherCard extends LitElement {
     }
 
     const forecastType = this.getIdealForecastType();
-    this.subscribedToForecast = this.hass.connection.subscribeMessage<ForecastEvent>(
-      evt => this.forecastEvent = evt,
-      {
-        type: 'weather/subscribe_forecast',
-        forecast_type: forecastType,
-        entity_id: this.config.entity
+    try {
+      const subscription = this.hass.connection.subscribeMessage<ForecastEvent>(
+        evt => this.acceptForecastEvent(evt),
+        {
+          type: 'weather/subscribe_forecast',
+          forecast_type: forecastType,
+          entity_id: this.config.entity
+        });
+      this.subscribedToForecast = subscription;
+      subscription.catch((error) => {
+        if (this.subscribedToForecast === subscription) {
+          this.subscribedToForecast = undefined;
+        }
+        console.warn('[hourly-weather] forecast subscription failed', error);
+        this.scheduleForecastRecovery(0);
       });
+      this.scheduleForecastRecovery(
+        this.hasUsableForecast(this.forecastEvent?.forecast)
+          ? FORECAST_STALE_AFTER_MS
+          : INITIAL_FORECAST_RECOVERY_DELAY_MS
+      );
+    } catch (error) {
+      console.warn('[hourly-weather] could not subscribe to forecast updates', error);
+      this.scheduleForecastRecovery(0);
+    }
   }
 
   private getIdealForecastType(): ForecastType {
@@ -257,6 +354,7 @@ export class HourlyWeatherCard extends LitElement {
 
   public disconnectedCallback(): void {
     super.disconnectedCallback();
+    this.stopForecastRecovery();
     this.unsubscribeForecastEvents();
   }
 
@@ -290,6 +388,9 @@ export class HourlyWeatherCard extends LitElement {
     const forecastTypeChanged = changedProps.has('config') &&
       this.config?.forecast_type !== previousConfig?.forecast_type;
 
+    if (entityChanged || forecastTypeChanged) {
+      this.forecastEvent = undefined;
+    }
     if (!this.subscribedToForecast || entityChanged || forecastTypeChanged) {
       this.subscribeToForecastEvents();
     }
@@ -341,7 +442,7 @@ export class HourlyWeatherCard extends LitElement {
     }
 
     if (!forecastNotAvailable && numSegments > (forecast.length - offset)) {
-      if (pending) return;
+      if (pending) return this.renderPendingCard(config);
       return await this._showError(this.localize('errors.too_many_segments_requested'));
     }
 
@@ -366,7 +467,7 @@ export class HourlyWeatherCard extends LitElement {
     }
 
     if (forecastNotAvailable) {
-      if (pending) return;
+      if (pending) return this.renderPendingCard(config);
       return html`
         <ha-card
           .header=${config.name}
@@ -428,6 +529,17 @@ export class HourlyWeatherCard extends LitElement {
         </div>
       </ha-card>
     `;
+  }
+
+  private renderPendingCard(config: HourlyWeatherCardConfig): TemplateResult {
+    return html`
+      <ha-card
+        .header=${config.name}
+        tabindex="0"
+        .label=${`Hourly Weather: ${config.entity || 'No Entity Defined'}`}
+      >
+        <div class="card-content forecast-pending" aria-busy="true"></div>
+      </ha-card>`;
   }
 
   private getConditionListFromForecast(forecast: ForecastSegment[], numSegments: number, offset: number): ConditionSpan[] {
@@ -742,6 +854,10 @@ export class HourlyWeatherCard extends LitElement {
 
   // https://lit.dev/docs/components/styles/
   static get styles(): CSSResultGroup {
-    return css``;
+    return css`
+      .forecast-pending {
+        min-height: 24px;
+      }
+    `;
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -121,3 +121,12 @@ export interface ForecastEvent {
   type: ForecastType;
   forecast: ForecastSegment[] | null;
 }
+
+export type ForecastServiceResponse = Record<string, {
+  forecast?: ForecastSegment[] | null;
+}>;
+
+export interface ForecastServiceCallResult {
+  response?: ForecastServiceResponse;
+  service_response?: ForecastServiceResponse;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -119,5 +119,5 @@ export type ForecastType = "hourly" | "daily" | "twice_daily";
 
 export interface ForecastEvent {
   type: ForecastType;
-  forecast: [ForecastSegment] | null;
+  forecast: ForecastSegment[] | null;
 }


### PR DESCRIPTION
## Summary

- preserve the last usable forecast when a subscription emits a transient empty update
- keep a small `ha-card` placeholder rendered while the initial forecast is pending
- recover stalled subscriptions through `weather.get_forecasts`, with a low-frequency health timer and retry handling
- cancel recovery timers when the card disconnects and reset state when the configured entity changes

The fallback does not poll while valid subscription events continue to arrive.

## Testing

- `npm run lint`
- `npm run build`
- `npm test` — 110/110 Cypress tests passing

Fixes #974.