### PR TITLE
Resubscribe when forecast_type changes

### DIFF
--- a/cypress/e2e/config.cy.ts
+++ b/cypress/e2e/config.cy.ts
@@ -246,6 +246,26 @@ describe('Config', () => {
       cy.enableForecastSubscriptions();
     });
 
+    it('resubscribes when forecast_type changes without changing entity', () => {
+      cy.window().then((win: any) => {
+        cy.spy(win.hourlyWeather.hass.connection, 'subscribeMessage').as('subscribeMessage');
+      });
+
+      cy.configure({ forecast_type: 'hourly' });
+      cy.configure({ forecast_type: 'daily' });
+
+      cy.get('@subscribeMessage').then((subscribeMessage: any) => {
+        const forecastSubscriptions = subscribeMessage.getCalls()
+          .map((call: any) => call.args[1])
+          .filter((message: any) => message.type === 'weather/subscribe_forecast');
+
+        expect(forecastSubscriptions).to.have.length(2);
+        expect(forecastSubscriptions[0].forecast_type).to.equal('hourly');
+        expect(forecastSubscriptions[1].forecast_type).to.equal('daily');
+        expect(forecastSubscriptions[1].entity_id).to.equal(forecastSubscriptions[0].entity_id);
+      });
+    });
+
     it('uses forecast from subscription when available', () => {
       cy.addEntity({
         'weather.fromSub': {

--- a/src/hourly-weather.ts
+++ b/src/hourly-weather.ts
@@ -284,8 +284,13 @@ export class HourlyWeatherCard extends LitElement {
       this.configRenderPending = false;
       this.triggerConfigRender();
     }
-    if (!this.subscribedToForecast ||
-      (changedProps.has('config') && this.config?.entity !== changedProps.get('config')?.entity)) {
+    const previousConfig = changedProps.get('config') as HourlyWeatherCardConfig | undefined;
+    const entityChanged = changedProps.has('config') &&
+      this.config?.entity !== previousConfig?.entity;
+    const forecastTypeChanged = changedProps.has('config') &&
+      this.config?.forecast_type !== previousConfig?.forecast_type;
+
+    if (!this.subscribedToForecast || entityChanged || forecastTypeChanged) {
       this.subscribeToForecastEvents();
     }
   }


### PR DESCRIPTION
## Summary

Changing `forecast_type` while keeping the same weather entity left the existing forecast subscription active. The card therefore continued receiving the old forecast granularity.

This change treats `forecast_type` as part of the subscription identity and recreates the subscription whenever it changes.

## Testing

- added a regression test that switches `hourly` to `daily` on the same entity
- `npm run build`
- `npm test` (109 tests passed)