### PR TITLE
Validate numeric card options strictly

### DIFF
--- a/cypress/e2e/config.cy.ts
+++ b/cypress/e2e/config.cy.ts
@@ -13,6 +13,19 @@ describe('Config', () => {
       .find('p')
       .should('have.text', 'num_segments must be a positive integer');
   });
+  it('rejects partially numeric and fractional num_segments values', () => {
+    cy.configure({ num_segments: '2x' });
+    cy.get('hui-error-card')
+      .shadow()
+      .find('p')
+      .should('have.text', 'num_segments must be a positive integer');
+
+    cy.configure({ num_segments: '2.9' });
+    cy.get('hui-error-card')
+      .shadow()
+      .find('p')
+      .should('have.text', 'num_segments must be a positive integer');
+  });
   it('errors for offset < 0', () => {
     cy.configure({
       offset: '-1'
@@ -21,6 +34,19 @@ describe('Config', () => {
       .shadow()
       .find('p')
       .should('have.text', 'offset must be a positive integer');
+  });
+  it('rejects non-integer offset and label_spacing values', () => {
+    cy.configure({ offset: '1.5' });
+    cy.get('hui-error-card')
+      .shadow()
+      .find('p')
+      .should('have.text', 'offset must be a positive integer');
+
+    cy.configure({ label_spacing: '2x' });
+    cy.get('hui-error-card')
+      .shadow()
+      .find('p')
+      .should('have.text', 'label_spacing must be a positive integer');
   });
   it('errors for num_segments > forecast length', () => {
     cy.configure({

--- a/src/hourly-weather.ts
+++ b/src/hourly-weather.ts
@@ -318,20 +318,20 @@ export class HourlyWeatherCard extends LitElement {
     const { forecast, pending } = this.getForecast();
     const windSpeedUnit = state.attributes.wind_speed_unit ?? '';
     const precipitationUnit = state.attributes.precipitation_unit ?? '';
-    const numSegments = parseInt(config.num_segments ?? config.num_hours ?? '12', 10);
-    const offset = parseInt(config.offset ?? '0', 10);
-    const labelSpacing = parseInt(config.label_spacing ?? '2', 10);
+    const numSegments = this.parseInteger(config.num_segments ?? config.num_hours ?? 12);
+    const offset = this.parseInteger(config.offset ?? 0);
+    const labelSpacing = this.parseInteger(config.label_spacing ?? 2);
     const forecastNotAvailable = !forecast || !forecast.length;
     const icon_fill = config.icon_fill;
     const hideMinutes = !!config.hide_minutes;
     const roundTemperatures = !!config.round_temperatures;
 
-    if (numSegments < 1) {
+    if (!Number.isInteger(numSegments) || numSegments < 1) {
       // REMARK: Ok, so I'm re-using a localized string here. Probably not the best, but it avoids repeating for no good reason
       return await this._showError(this.localize('errors.offset_must_be_positive_int', 'offset', 'num_segments'));
     }
 
-    if (offset < 0) {
+    if (!Number.isInteger(offset) || offset < 0) {
       return await this._showError(this.localize('errors.offset_must_be_positive_int'));
     }
 
@@ -340,7 +340,7 @@ export class HourlyWeatherCard extends LitElement {
       return await this._showError(this.localize('errors.too_many_segments_requested'));
     }
 
-    if (labelSpacing < 1) {
+    if (!Number.isInteger(labelSpacing) || labelSpacing < 1) {
       // REMARK: Ok, so I'm re-using a localized string here. Probably not the best, but it avoids repeating for no good reason
       return await this._showError(this.localize('errors.offset_must_be_positive_int', 'offset', 'label_spacing'));
     }
@@ -440,6 +440,18 @@ export class HourlyWeatherCard extends LitElement {
       }
     }
     return res;
+  }
+
+  private parseInteger(value: unknown): number {
+    if (typeof value === 'number') {
+      return Number.isInteger(value) ? value : Number.NaN;
+    }
+    if (typeof value !== 'string' || value.trim() === '') {
+      return Number.NaN;
+    }
+
+    const parsed = Number(value);
+    return Number.isInteger(parsed) ? parsed : Number.NaN;
   }
 
   /**


### PR DESCRIPTION
## Summary

- replace permissive `parseInt` parsing for `num_segments`, `offset`, and `label_spacing`
- reject partial values such as `2x` and fractional values such as `2.9`
- handle empty and non-numeric values as validation errors instead of allowing `NaN` into rendering
- continue accepting integer strings produced by templates and numeric values from the editor

## Testing

- added regression coverage for partial and fractional inputs
- `npm run build`
- `npm test` (110 tests passed)