### PR TITLE
[#990] Do not rotate calm wind barb

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from "cypress";
 export default defineConfig({
   projectId: 'o468vw',
   includeShadowDom: true,
+  allowCypressEnv: false,
   e2e: {
     baseUrl: 'http://localhost:8000/cypress/fixtures/'
   },

--- a/cypress/e2e/config.cy.ts
+++ b/cypress/e2e/config.cy.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import type * as Sinon from "sinon";
 
 describe('Config', () => {

--- a/cypress/e2e/weather-bar.cy.ts
+++ b/cypress/e2e/weather-bar.cy.ts
@@ -706,6 +706,102 @@ describe('Weather bar', () => {
         });
     });
 
+    it('does not rotate calm barb', () => {
+      cy.addEntity({
+        'weather.calm_start': {
+          attributes: {
+            wind_speed_unit: 'mph',
+            forecast: [
+              {
+                "datetime": "2022-07-21T17:00:00+00:00",
+                "precipitation": 0,
+                "precipitation_probability": 0,
+                "pressure": 1007,
+                "wind_speed": 0.67,
+                "wind_bearing": 123,
+                "condition": "cloudy",
+                "clouds": 60,
+                "temperature": 84
+              },
+              {
+                "datetime": "2022-07-21T18:00:00+00:00",
+                "precipitation": 0.35,
+                "precipitation_probability": 0,
+                "pressure": 1007,
+                "wind_speed": 0.07,
+                "wind_bearing": 123,
+                "condition": "cloudy",
+                "clouds": 75,
+                "temperature": 85
+              },
+              {
+                "datetime": "2022-07-21T19:00:00+00:00",
+                "precipitation": 0,
+                "precipitation_probability": 0,
+                "pressure": 1007,
+                "wind_speed": 0,
+                "wind_bearing": 123,
+                "condition": "cloudy",
+                "clouds": 60,
+                "temperature": 85
+              },
+              {
+                "datetime": "2022-07-21T20:00:00+00:00",
+                "precipitation": 1.3,
+                "precipitation_probability": 1,
+                "pressure": 1007,
+                "wind_speed": 2.2369362921, // 1 m/s
+                "wind_bearing": 304,
+                "condition": "partlycloudy",
+                "clouds": 49,
+                "temperature": 84
+              },
+              {
+                "datetime": "2022-07-21T21:00:00+00:00",
+                "precipitation": 0,
+                "precipitation_probability": 1,
+                "pressure": 1007,
+                "wind_speed": 5.78,
+                "wind_bearing": 290,
+                "condition": "partlycloudy",
+                "clouds": 34,
+                "temperature": 84
+              },
+              {
+                "datetime": "2022-07-21T22:00:00+00:00",
+                "precipitation": 0,
+                "precipitation_probability": 1,
+                "pressure": 1008,
+                "wind_speed": 5.06,
+                "wind_bearing": 285,
+                "condition": "partlycloudy",
+                "clouds": 19,
+                "temperature": 83
+              }
+            ]
+          }
+        }
+      });
+      cy.configure({
+        entity: 'weather.calm_start',
+        num_segments: '6',
+        label_spacing: '1',
+        show_wind: 'barb'
+      });
+      cy.get('weather-bar')
+        .shadow()
+        .find('div.axes > div.bar-block div.wind span')
+        .should('have.length', 6)
+        .each((el, i) => {
+          cy.wrap(el).find('svg').as(`wind-${i}`).should('exist');
+          if (i > 2) {
+            cy.get(`@wind-${i}`).should('have.attr', 'style', `transform:rotate(${expectedWindBearings[i]}deg);`);
+          } else {
+            cy.get(`@wind-${i}`).should('have.attr', 'style', '');
+          }
+        });
+    });
+
     it('shows wind barbs along with speed if specified in config', () => {
       cy.configure({
         show_wind: 'barb-and-speed'

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -18,3 +18,12 @@ import './commands'
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')
+
+Cypress.on('uncaught:exception', (err) => {
+  if (err.message.includes('ResizeObserver loop completed with undelivered notifications') ||
+    err.message.includes('ResizeObserver loop limit exceeded')) {
+    // Returning false here prevents Cypress from failing the test
+    return false;
+  }
+  return true; // Let other errors fail the test
+});

--- a/src/weather-bar.ts
+++ b/src/weather-bar.ts
@@ -169,8 +169,8 @@ export class WeatherBar extends LitElement {
           <div class="bar-block-bottom">
             <div class="date">${renderedDate}</div>
             <div class="hour">${hideHours ? null : this.has_current_segment && i === 0
-              ? html`<span class="current-time" title=${this.current_time}>${this.current_label}</span>`
-              : hour}</div>
+          ? html`<span class="current-time" title=${this.current_time}>${this.current_label}</span>`
+          : hour}</div>
             <div class="temperature">${hideTemperature ? null : html`${temperature}&deg;`}</div>
             <div class="wind">${wind}</div>
             <div class="precipitation">${precipitation}</div>
@@ -227,10 +227,11 @@ export class WeatherBar extends LitElement {
   }
 
   private getWindBarb(speed: number, direction: number): TemplateResult {
+    const isCalm = speed < 1.0;
     const svgStyles = {
       transform: `rotate(${direction}deg)`
     };
-    return html`<svg xmlns="http://www.w3.org/2000/svg" viewBox="70 40 120 120" class="barb" style=${styleMap(svgStyles)}>
+    return html`<svg xmlns="http://www.w3.org/2000/svg" viewBox="70 40 120 120" class="barb" style=${isCalm ? undefined : styleMap(svgStyles)}>
       ${getWindBarbSVG(speed)}
     </svg>`;
   }


### PR DESCRIPTION
Fixes #990 

When showing the calm wind barb (< 1.0 m/s wind), do not rotate for wind direction to avoid subtle shifts in the calm dot barb.