### PR TITLE
Add Serbian (Latin) translation (sr-Latn)

### DIFF
--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -1,4 +1,4 @@
-name: 'Translate strings'
+name: "Translate strings"
 
 on:
   push:
@@ -18,17 +18,18 @@ jobs:
         id: translate
         uses: msnyder-msft/i18n-auto-translation-action@v1.0.0
         with:
-            provider: 'google-official'
-            subscriptionKey: '${{ secrets.TRANSLATOR_SUBSCRIPTION_KEY }}'
-            filePath: './src/localize/languages/en.json'
-            from: 'en'
-            to: 'bg,cs,da,de,es,fr,hu,it,nb,nl,pl,pt,ru,sk,tr,uk,zh'
-            debug: false
+          provider: "google-official"
+          subscriptionKey: "${{ secrets.TRANSLATOR_SUBSCRIPTION_KEY }}"
+          filePath: "./src/localize/languages/en.json"
+          from: "en"
+          to: "bg,cs,da,de,es,fr,hu,it,nb,nl,pl,pt,ru,sk,tr,uk,zh"
+          debug: false
 
       - name: Copy new strings to sub-locales
         uses: ./.github/actions/copy-to-sub-locales
         with:
-          mappings: pt=>pt-BR,nb=>nn-NO
+          # Google translate does not support sr-Latn, so we just copy English strings to it for new strings.
+          mappings: pt=>pt-BR,nb=>nn-NO,en=>sr-Latn
 
       - name: Get current branch name
         id: branch_name
@@ -38,8 +39,8 @@ jobs:
         uses: devops-infra/action-commit-push@v1.5.0
         continue-on-error: true
         with:
-            github_token: '${{ secrets.GITHUB_TOKEN }}'
-            commit_prefix: '[Auto] '
-            commit_message: 'Adding updated localization files'
-            force: false
-            target_branch: ${{steps.vars.branch_name.current_branch}}
+          github_token: "${{ secrets.GITHUB_TOKEN }}"
+          commit_prefix: "[Auto] "
+          commit_message: "Adding updated localization files"
+          force: false
+          target_branch: ${{steps.vars.branch_name.current_branch}}

--- a/cypress/e2e/localization.cy.ts
+++ b/cypress/e2e/localization.cy.ts
@@ -59,6 +59,7 @@ describe('Localization', () => {
     'nn-NO': 'Skya',
     ru: 'Облачно',
     sk: 'Zamračené',
+    'sr-Latn': 'Oblačno',
     tr: 'Bulutlu',
     uk: 'Хмарно',
     zh: '多云'

--- a/src/localize/languages/sr-Latn.json
+++ b/src/localize/languages/sr-Latn.json
@@ -1,0 +1,81 @@
+{
+  "common": {
+    "version": "Verzija",
+    "title": "Prognoza po satima",
+    "title_card": "Kartica sa prognozom po satima",
+    "description": "Kartica za prikaz vremenskih uslova po satima u obliku trake.",
+    "invalid_configuration": "Neispravna konfiguracija"
+  },
+  "editor": {
+    "entity": "Entitet (Obavezno)",
+    "name": "Naziv (Opciono)",
+    "segments_to_show": "Broj segmenata prognoze za prikaz (Opciono)",
+    "offset": "Broj segmenata prognoze za pomeranje početka (Opciono)",
+    "icons": "Prikaz ikone umesto tekstualnih oznaka",
+    "show_current": "Prikaži trenutno vreme kao prvi segment",
+    "auto_label_spacing": "Automatski smanji broj oznaka kada je kartica uska",
+    "label_spacing": "Razmak između oznaka vremena i temperature izražen u broju segmenata (Opciono)",
+    "show_wind": "Prikaži brzinu i smer vetra",
+    "show_date": "Prikaži datume",
+    "show_precipitation_amounts": "Prikaz količine padavina",
+    "show_precipitation_probability": "Prikaz verovatnoće padavina",
+    "none": "Nijedno",
+    "speed_and_direction": "Brzina i smer",
+    "speed_only": "Samo brzina",
+    "direction_only": "Samo smer",
+    "barb": "Kao strelica za vetar (barb)",
+    "barb_and_speed": "Kao strelica za vetar i brzina",
+    "barb_and_direction": "Kao strelica za vetar i smer",
+    "barb_speed_and_direction": "Kao strelica za vetar, brzina i smer",
+    "all": "Sve",
+    "on_day_boundaries": "Na granicama dana"
+  },
+  "errors": {
+    "missing_entity": "entitet nedostaje u konfiguraciji",
+    "too_many_segments_requested": "Zatraženo je previše segmenata prognoze u 'num_segments'. Broj mora biti manji ili jednak broju segmenata u samom entitetu prognoze.",
+    "must_be_int": "Mora biti paran ceo broj veći od ili jednak 2",
+    "invalid_colors": "Sledeće boje u vašoj konfiguraciji nisu ispravne:",
+    "must_be_positive_int": "Mora biti pozitivan ceo broj",
+    "offset_must_be_positive_int": "'offset' mora biti pozitivan ceo broj",
+    "forecast_not_available": "Prognoza nije dostupna",
+    "check_entity": "Proverite podešeni entitet za prognozu.",
+    "invalid_value_icon_fill": "'icon_fill' mora biti pozitivan ceo broj ili jedna od vrednosti: 'single' ili 'full'"
+  },
+  "conditions": {
+    "clear": "Vedro",
+    "cloudy": "Oblačno",
+    "fog": "Magla",
+    "hail": "Grad",
+    "thunderstorm": "Grmljavina",
+    "partlyCloudy": "Delimično oblačno",
+    "partlyCloudyNight": "Delimično oblačno (noću)",
+    "heavyRain": "Jaka kiša",
+    "rain": "Kiša",
+    "snow": "Sneg",
+    "mixedPrecip": "Susnežica",
+    "sunny": "Sunčano",
+    "windy": "Vetrovito"
+  },
+  "direction": {
+    "n": "S",
+    "nne": "SSI",
+    "ne": "SI",
+    "ene": "ISI",
+    "e": "I",
+    "ese": "IJI",
+    "se": "JI",
+    "sse": "JJI",
+    "s": "J",
+    "ssw": "JJZ",
+    "sw": "JZ",
+    "wsw": "ZJZ",
+    "w": "Z",
+    "wnw": "ZZS",
+    "nw": "SZ",
+    "nnw": "SSZ"
+  },
+  "card": {
+    "now": "Sada",
+    "chance_of_precipitation": "{0}% šanse za padavine"
+  }
+}

--- a/src/localize/localize.ts
+++ b/src/localize/localize.ts
@@ -15,6 +15,7 @@ import * as pt from './languages/pt.json';
 import * as pt_BR from './languages/pt-BR.json';
 import * as ru from './languages/ru.json';
 import * as sk from './languages/sk.json';
+import * as sr_Latn from './languages/sr-Latn.json';
 import * as tr from './languages/tr.json';
 import * as uk from './languages/uk.json';
 import * as zh from './languages/zh.json';
@@ -38,6 +39,7 @@ const languages: any = {
   pt_BR,
   ru,
   sk,
+  sr_Latn,
   tr,
   uk,
   zh,
@@ -46,9 +48,9 @@ const languages: any = {
 export function getLocalizer(configuredLanguage: string | undefined, haServerLanguage: string | undefined) {
   return function localize(string: string, search = '', replace = ''): string {
     const lang = (configuredLanguage ||
-                  localStorage.getItem('selectedLanguage') ||
-                  haServerLanguage ||
-                  'en').replace(/['"]+/g, '').replace('-', '_');
+      localStorage.getItem('selectedLanguage') ||
+      haServerLanguage ||
+      'en').replace(/['"]+/g, '').replace('-', '_');
 
     let translated: string;
 


### PR DESCRIPTION
Hi! 

I have added the Serbian (Latin) translation file for this weather card. Here are the language details:

- **English Name:** Serbian (Latin)
- **Native Name:** Srpski (latinica)
- **Suggested ISO/BCP 47 code:** `sr-Latn`

Thank you for maintaining this great project!